### PR TITLE
Add dev server launch config and fix Turbopack workspace root

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "nfc-nurnberg-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Pin turbopack.root in next.config.ts so the dev server resolves modules from this worktree instead of the parent repo's directory tree, which was causing it to pick up an unrelated src/proxy.ts.