### PR TITLE
docs: add useful scripts table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,16 @@ npm run dev
 
 Log in with the printed Administrator credentials at `/login`, then create Player/Trainer accounts from `/dashboard/users`.
 
+### Useful scripts
+
+| Command               | What it does                                                        |
+| ---------------------- | -------------------------------------------------------------------- |
+| `npm run build`        | Production build — run this and `npm run lint` before considering a change done |
+| `npm run lint`         | ESLint                                                                |
+| `npm run test:smoke`   | Playwright smoke test (`scripts/smoke-test.ts`) against an already-running dev server — exercises guest/Admin/Trainer/Player flows end to end, creating and cleaning up its own throwaway data |
+| `npm run db:migrate`   | Apply Prisma migrations (`prisma migrate dev`)                       |
+| `npm run db:seed`      | Re-run the seed script (`prisma db seed`)                            |
+| `npm run db:reset`     | Drop, recreate, and reseed the local database — **destructive**, local dev only |
+| `npm run db:studio`    | Open Prisma Studio, a visual DB browser                              |
+
 See `CLAUDE.md` for architecture notes, the auth/role model, and gotchas already hit while building this.


### PR DESCRIPTION
Adds a "Useful scripts" table to the README's Development section, surfacing npm scripts (build, lint, test:smoke, db:reset, db:studio) that already exist in package.json and are documented in CLAUDE.md but were missing from the README.

Closes #11.

Generated with [Claude Code](https://claude.ai/code)