### PR TITLE
Document target role & permission model for all user roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,15 @@ There is no self-registration and no password reset flow. Admin accounts are
 created by `prisma/seed.ts`; everyone else is created from
 `/dashboard/users` by an Admin.
 
+**The list above is as-built. The club's agreed target model is
+`docs/roles-and-permissions.md`** — read it before changing anything about
+roles, and treat it as the intent when the two disagree. It is a spec, not
+yet implemented; it ends with a current-vs-target gap table. Headline
+differences: Trainers become club-wide (no `team` scoping), Players see the
+whole club schedule, account management grows edit/reset/soft-disable, a
+super-admin flag gates Admin-on-Admin management and the audit log, and public
+content moves out of JSON into the database.
+
 ## Known gotchas (hit these already — don't rediscover them)
 
 - **Next.js 16 renamed the `middleware` file convention to `proxy`.** Route

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,12 @@ created by `prisma/seed.ts`; everyone else is created from
 `/dashboard/users` by an Admin.
 
 **The list above is as-built. The club's agreed target model is
-`docs/roles-and-permissions.md`** — read it before changing anything about
-roles, and treat it as the intent when the two disagree. It is a spec, not
-yet implemented; it ends with a current-vs-target gap table. Headline
+`docs/roles-and-permissions.md`** (index + permission matrix + shared rules,
+with one file per role under `docs/roles/`: `guest.md`, `player.md`,
+`trainer.md`, `admin.md`, `super-admin.md`) — read it before changing
+anything about roles, and treat it as the intent when the two disagree. It is
+a spec, not yet implemented; every page ends with a current-vs-target gap
+table, and the index carries a suggested build order. Headline
 differences: Trainers become club-wide (no `team` scoping), Players see the
 whole club schedule, account management grows edit/reset/soft-disable, a
 super-admin flag gates Admin-on-Admin management and the audit log, and public

--- a/docs/roles-and-permissions.md
+++ b/docs/roles-and-permissions.md
@@ -4,11 +4,21 @@ Specification of what each user role may and may not do on the NFC Nürnberg
 site. Decided in conversation with the club, 2026-08-08.
 
 **Status: specification only.** This describes the *target* model. Parts of it
-are not built yet — see [Current vs. target](#current-vs-target) at the end for
-the gap between this document and the code as it stands. Where the two differ,
-this document is the intent and the code is the backlog.
+are not built yet — each role page ends with a current-vs-target table, and
+this page carries the consolidated one. Where this specification and the code
+disagree, this is the intent and the code is the backlog.
 
-## Roles at a glance
+## The roles
+
+| Role | Summary |
+|---|---|
+| [Guest](roles/guest.md) | No account. Full public read access, names visible, no personal details. |
+| [Player](roles/player.md) | Read-only member. Whole-club schedule, own attendance, own fee record. |
+| [Trainer](roles/trainer.md) | Coach, club-wide. Owns events and attendance; nothing else. |
+| [Admin](roles/admin.md) | Runs the club. Accounts, event override, full CMS, records. |
+| [Super-admin](roles/super-admin.md) | Flag on an Admin. Manages Admins, holds the audit log. |
+
+## Permission matrix
 
 | | Guest | Player | Trainer | Admin | Super-admin |
 |---|---|---|---|---|---|
@@ -33,148 +43,9 @@ allows, rather than assuming a hierarchy.
 
 ---
 
-## Guest
-
-Anyone visiting the site without logging in. No account, no session.
-
-**Can:**
-- Read every public page: home, club info, teams, news, training/game
-  schedule, shop, contact.
-- See the public roster: player **names and avatars** for both teams.
-
-**Cannot:**
-- See any personal detail beyond a name — no email addresses, no phone
-  numbers, no attendance data, no fee records. "Public, minus personal
-  details" is the rule; names themselves stay public.
-- Reach anything under `/dashboard/**`.
-
-**Rule:** never gate a public page behind login. The public site is the club's
-shop window and must stay fully readable to a stranger.
-
----
-
-## Player
-
-A club member on a team roster. The role is **read-only**.
-
-**Can:**
-- See the **entire club schedule** — both teams' training sessions and games,
-  plus club-wide events. Nothing is hidden between teams.
-- See **their own attendance record only**: whether they were marked present,
-  absent, or excused, across past sessions.
-- See **their own membership/fee contribution status** — what they have paid
-  and what is outstanding. Their own record only, never anyone else's.
-- Set a new password **when forced to** after an Admin reset (see
-  [Passwords](#passwords)).
-
-**Cannot:**
-- See any teammate's attendance, individually or in aggregate.
-- See anyone else's fee records.
-- Mark or RSVP their own attendance — attendance is the Trainer's record
-  alone. A Player who cannot attend tells the Trainer outside the app.
-- Change their own password voluntarily, edit their contact details, create or
-  edit anything at all.
-
-**Roster link:** creating a Player account **auto-creates their roster entry**,
-so a login and a roster record can never drift apart. The auto-created entry is
-**hidden from the public site until an Admin publishes it** — real names go on a
-public website only by deliberate act, not as a side effect of account creation.
-
-**No self-registration.** Player accounts are created by an Admin.
-
----
-
-## Trainer
-
-A coach. **Club-wide, not scoped to a team** — any Trainer may run sessions for
-any team.
-
-**Can:**
-- Create and edit **training sessions** for any team: date, time, venue,
-  address, training plan, notes.
-- Create and edit **games/matches** for any team, including the opponent.
-- **Cancel or delete** events, so a called-off session stops showing on the
-  public site.
-- **Mark attendance** for any session (present / absent / excused / unknown).
-  Attendance is the Trainer's record; players do not self-mark.
-- View **attendance reports** — per-player and per-team summaries over time,
-  the same figures the Admin sees.
-
-**Cannot:**
-- Create or edit **club-wide ("both teams") events** — Admin only.
-- Create, edit, disable, or delete **user accounts** of any kind, including
-  Player logins for players they coach.
-- Manage **public content** — no news, no roster editing, no shop, no club
-  info.
-- See **membership or fee records** for anyone.
-- See the **audit log**.
-- See members' **contact details** — a Trainer reaches players through channels
-  the club already uses, not through the site.
-
-**No team field.** Because Trainers are club-wide, a Trainer account carries no
-`team` value at all — like an Admin. The account form stops asking for one.
-
----
-
-## Admin
-
-Runs the club's day-to-day operations in the app.
-
-**Accounts (Players and Trainers):**
-- **Create** accounts — name, email, temporary password, role, and (for
-  Players) the auto-created roster entry.
-- **Edit** existing accounts — name, email, role, roster link.
-- **Reset passwords**, issuing a new temporary password.
-- **Deactivate** accounts. Deactivation is a **soft disable**: the member can no
-  longer log in, but their events, attendance history, and roster entry are all
-  retained. Club records are never destroyed by a departure.
-
-**Events — full override:**
-- Create, edit, cancel, and delete **any event of any team**, including events a
-  Trainer created. Admin is the backstop when a Trainer is unavailable.
-- **Club-wide ("both teams") events are Admin-only** — no Trainer may create
-  them.
-- Mark attendance on any session.
-
-**Content — full CMS:**
-Admins manage all public website content from the dashboard: news articles,
-team rosters, shop products, club info (mission, motto, values, contact), and
-membership tiers. This is what moves the site off dev-edited JSON files
-(see [Data model consequences](#data-model-consequences)).
-
-**Also:**
-- Publish or unpublish auto-created roster entries.
-- View **attendance reports** across the club.
-- View **membership/fee contribution records** for all members.
-
-**Cannot:**
-- Create, edit, promote, demote, or disable **another Admin** — that is
-  super-admin territory.
-- Grant or revoke the super-admin flag.
-- View the **audit log**.
-
----
-
-## Super-admin
-
-Not a separate role — a **flag on an Admin account**. `role` stays `ADMIN`; a
-boolean marks the holder as a super-admin. The bootstrap Administrator created
-by `prisma/seed.ts` gets the flag automatically.
-
-**Only a super-admin can:**
-- Create, edit, demote, or disable **Admin accounts**.
-- **Grant the super-admin flag** to another Admin. Multiple super-admins may
-  exist at once, deliberately: the club should never be one lost account away
-  from an unmanageable site.
-- View the **audit log** of admin actions — who created, edited, or disabled
-  which account or event, and when. Restricting this to super-admins keeps
-  ordinary Admins accountable to a smaller circle.
-
-A super-admin holds every Admin permission in addition to the above.
-
----
-
 ## Cross-cutting rules
+
+These apply to every role and are not repeated in full on the role pages.
 
 ### Passwords
 
@@ -189,22 +60,23 @@ A super-admin holds every Admin permission in addition to the above.
 
 ### Deactivation
 
-Soft disable everywhere. A disabled account cannot authenticate, but no
-history is deleted: events they created, attendance they recorded, and their
-roster entry all survive. Hard deletion is not a supported operation in the app.
+Soft disable everywhere. A disabled account cannot authenticate, but no history
+is deleted: events they created, attendance they recorded, and their roster
+entry all survive. Hard deletion is not a supported operation in the app.
 
 ### Authorization is enforced server-side
 
-Page-level role checks are UX — they keep the wrong buttons off the screen.
-The **server action is the actual security boundary** and re-checks role and
-permission independently. Every rule above must hold even if a user hand-crafts
-a request.
+Page-level role checks are UX — they keep the wrong buttons off the screen. The
+**server action is the actual security boundary** and re-checks role and
+permission independently. Every rule in this specification must hold even if a
+user hand-crafts a request.
 
 ---
 
 ## Data model consequences
 
-Decisions above that the current schema and content layer do not yet support:
+Decisions in this specification that the current schema and content layer do
+not yet support:
 
 1. **All public content moves into the database.** Rosters, news, club info,
    and membership tiers leave `src/lib/data/*.json` and become Prisma models,
@@ -227,7 +99,8 @@ Decisions above that the current schema and content layer do not yet support:
 
 ## Current vs. target
 
-What the code does **today** (2026-08-08), against the spec above:
+What the code does **today** (2026-08-08), against the specification above.
+Per-role detail lives on each role page.
 
 | Area | Today | Target |
 |---|---|---|
@@ -252,3 +125,16 @@ Two rows are worth calling out because they **reduce** existing access rather
 than extend it — implementing them is a behavior change, not just a feature:
 Trainers gaining club-wide reach removes the team boundary that currently
 exists, and ordinary Admins lose the ability to create fellow Admins.
+
+### Suggested build order
+
+1. **Super-admin flag** — must land before Admins lose Admin-management, or
+   nobody can add an Admin. See [Super-admin](roles/super-admin.md).
+2. **`User` field additions** (`isActive`, `mustChangePassword`) and the
+   account edit/reset/disable UI — additive, no content migration needed.
+3. **Trainer de-scoping** — removes `team` checks, touches forms and helpers.
+4. **Player schedule widening** — a one-line scope change plus tests.
+5. **Content migration to the DB** — the largest piece; unblocks roster
+   auto-create, publish gating, and the CMS.
+6. **Attendance reports, fee records, audit log** — new features on top of the
+   migrated model.

--- a/docs/roles-and-permissions.md
+++ b/docs/roles-and-permissions.md
@@ -1,0 +1,254 @@
+# Roles & Permissions
+
+Specification of what each user role may and may not do on the NFC Nürnberg
+site. Decided in conversation with the club, 2026-08-08.
+
+**Status: specification only.** This describes the *target* model. Parts of it
+are not built yet — see [Current vs. target](#current-vs-target) at the end for
+the gap between this document and the code as it stands. Where the two differ,
+this document is the intent and the code is the backlog.
+
+## Roles at a glance
+
+| | Guest | Player | Trainer | Admin | Super-admin |
+|---|---|---|---|---|---|
+| Read public pages | ✅ | ✅ | ✅ | ✅ | ✅ |
+| See full club schedule (member area) | — | ✅ | ✅ | ✅ | ✅ |
+| See own attendance record | — | ✅ | ✅ | ✅ | ✅ |
+| See other members' attendance | — | ❌ | ✅ | ✅ | ✅ |
+| Create/edit events (per team) | — | ❌ | ✅ any team | ✅ any team | ✅ |
+| Create club-wide ("both") events | — | ❌ | ❌ | ✅ | ✅ |
+| Cancel/delete events | — | ❌ | ✅ | ✅ | ✅ |
+| Mark attendance | — | ❌ | ✅ | ✅ | ✅ |
+| Attendance reports | — | ❌ | ✅ | ✅ | ✅ |
+| Manage Player/Trainer accounts | — | ❌ | ❌ | ✅ | ✅ |
+| Manage Admin accounts | — | ❌ | ❌ | ❌ | ✅ |
+| Manage public content (CMS) | — | ❌ | ❌ | ✅ | ✅ |
+| Membership/fee records | — | own only | ❌ | ✅ all | ✅ all |
+| Audit log | — | ❌ | ❌ | ❌ | ✅ |
+| Set own password | — | on forced reset | on forced reset | on forced reset | on forced reset |
+
+Roles are cumulative in practice but not in code: each check names the roles it
+allows, rather than assuming a hierarchy.
+
+---
+
+## Guest
+
+Anyone visiting the site without logging in. No account, no session.
+
+**Can:**
+- Read every public page: home, club info, teams, news, training/game
+  schedule, shop, contact.
+- See the public roster: player **names and avatars** for both teams.
+
+**Cannot:**
+- See any personal detail beyond a name — no email addresses, no phone
+  numbers, no attendance data, no fee records. "Public, minus personal
+  details" is the rule; names themselves stay public.
+- Reach anything under `/dashboard/**`.
+
+**Rule:** never gate a public page behind login. The public site is the club's
+shop window and must stay fully readable to a stranger.
+
+---
+
+## Player
+
+A club member on a team roster. The role is **read-only**.
+
+**Can:**
+- See the **entire club schedule** — both teams' training sessions and games,
+  plus club-wide events. Nothing is hidden between teams.
+- See **their own attendance record only**: whether they were marked present,
+  absent, or excused, across past sessions.
+- See **their own membership/fee contribution status** — what they have paid
+  and what is outstanding. Their own record only, never anyone else's.
+- Set a new password **when forced to** after an Admin reset (see
+  [Passwords](#passwords)).
+
+**Cannot:**
+- See any teammate's attendance, individually or in aggregate.
+- See anyone else's fee records.
+- Mark or RSVP their own attendance — attendance is the Trainer's record
+  alone. A Player who cannot attend tells the Trainer outside the app.
+- Change their own password voluntarily, edit their contact details, create or
+  edit anything at all.
+
+**Roster link:** creating a Player account **auto-creates their roster entry**,
+so a login and a roster record can never drift apart. The auto-created entry is
+**hidden from the public site until an Admin publishes it** — real names go on a
+public website only by deliberate act, not as a side effect of account creation.
+
+**No self-registration.** Player accounts are created by an Admin.
+
+---
+
+## Trainer
+
+A coach. **Club-wide, not scoped to a team** — any Trainer may run sessions for
+any team.
+
+**Can:**
+- Create and edit **training sessions** for any team: date, time, venue,
+  address, training plan, notes.
+- Create and edit **games/matches** for any team, including the opponent.
+- **Cancel or delete** events, so a called-off session stops showing on the
+  public site.
+- **Mark attendance** for any session (present / absent / excused / unknown).
+  Attendance is the Trainer's record; players do not self-mark.
+- View **attendance reports** — per-player and per-team summaries over time,
+  the same figures the Admin sees.
+
+**Cannot:**
+- Create or edit **club-wide ("both teams") events** — Admin only.
+- Create, edit, disable, or delete **user accounts** of any kind, including
+  Player logins for players they coach.
+- Manage **public content** — no news, no roster editing, no shop, no club
+  info.
+- See **membership or fee records** for anyone.
+- See the **audit log**.
+- See members' **contact details** — a Trainer reaches players through channels
+  the club already uses, not through the site.
+
+**No team field.** Because Trainers are club-wide, a Trainer account carries no
+`team` value at all — like an Admin. The account form stops asking for one.
+
+---
+
+## Admin
+
+Runs the club's day-to-day operations in the app.
+
+**Accounts (Players and Trainers):**
+- **Create** accounts — name, email, temporary password, role, and (for
+  Players) the auto-created roster entry.
+- **Edit** existing accounts — name, email, role, roster link.
+- **Reset passwords**, issuing a new temporary password.
+- **Deactivate** accounts. Deactivation is a **soft disable**: the member can no
+  longer log in, but their events, attendance history, and roster entry are all
+  retained. Club records are never destroyed by a departure.
+
+**Events — full override:**
+- Create, edit, cancel, and delete **any event of any team**, including events a
+  Trainer created. Admin is the backstop when a Trainer is unavailable.
+- **Club-wide ("both teams") events are Admin-only** — no Trainer may create
+  them.
+- Mark attendance on any session.
+
+**Content — full CMS:**
+Admins manage all public website content from the dashboard: news articles,
+team rosters, shop products, club info (mission, motto, values, contact), and
+membership tiers. This is what moves the site off dev-edited JSON files
+(see [Data model consequences](#data-model-consequences)).
+
+**Also:**
+- Publish or unpublish auto-created roster entries.
+- View **attendance reports** across the club.
+- View **membership/fee contribution records** for all members.
+
+**Cannot:**
+- Create, edit, promote, demote, or disable **another Admin** — that is
+  super-admin territory.
+- Grant or revoke the super-admin flag.
+- View the **audit log**.
+
+---
+
+## Super-admin
+
+Not a separate role — a **flag on an Admin account**. `role` stays `ADMIN`; a
+boolean marks the holder as a super-admin. The bootstrap Administrator created
+by `prisma/seed.ts` gets the flag automatically.
+
+**Only a super-admin can:**
+- Create, edit, demote, or disable **Admin accounts**.
+- **Grant the super-admin flag** to another Admin. Multiple super-admins may
+  exist at once, deliberately: the club should never be one lost account away
+  from an unmanageable site.
+- View the **audit log** of admin actions — who created, edited, or disabled
+  which account or event, and when. Restricting this to super-admins keeps
+  ordinary Admins accountable to a smaller circle.
+
+A super-admin holds every Admin permission in addition to the above.
+
+---
+
+## Cross-cutting rules
+
+### Passwords
+
+- There is **no self-registration** and **no email-based password reset**.
+  Accounts are created by an Admin (or, for Admins, by a super-admin).
+- The creating Admin sets a **temporary password** and communicates it to the
+  member out of band.
+- On the member's next login after account creation or an Admin reset, they are
+  **forced to set a new password** before reaching the dashboard.
+- Outside that forced flow there is **no voluntary "change my password" page**.
+  A member who wants a new password asks an Admin to reset it.
+
+### Deactivation
+
+Soft disable everywhere. A disabled account cannot authenticate, but no
+history is deleted: events they created, attendance they recorded, and their
+roster entry all survive. Hard deletion is not a supported operation in the app.
+
+### Authorization is enforced server-side
+
+Page-level role checks are UX — they keep the wrong buttons off the screen.
+The **server action is the actual security boundary** and re-checks role and
+permission independently. Every rule above must hold even if a user hand-crafts
+a request.
+
+---
+
+## Data model consequences
+
+Decisions above that the current schema and content layer do not yet support:
+
+1. **All public content moves into the database.** Rosters, news, club info,
+   and membership tiers leave `src/lib/data/*.json` and become Prisma models,
+   because Admins now edit them from the dashboard and Player accounts
+   auto-create roster entries. `src/lib/repository.ts` keeps its interface —
+   only its implementation changes, so callers stay untouched. Shop products
+   are already in the DB.
+2. **`Player` becomes a table**, with a `published` flag driving public
+   visibility and a relation to the `User` who owns the login.
+3. **`User.team` is dropped for Trainers** (club-wide) and is meaningful only
+   for Players, whose team follows their roster entry.
+4. **New `User` fields**: `isSuperAdmin`, `isActive` (soft disable), and
+   `mustChangePassword` (forced reset flow).
+5. **New models**: membership/fee contributions, and an audit log of admin
+   actions.
+6. **Attendance** keeps its `playerSlug` link but points at the `Player` table
+   rather than a JSON file.
+
+---
+
+## Current vs. target
+
+What the code does **today** (2026-08-08), against the spec above:
+
+| Area | Today | Target |
+|---|---|---|
+| Roles | `PLAYER`, `TRAINER`, `ADMIN` | Same three + super-admin flag |
+| Trainer scope | Scoped to one team (`canManageTeam`) | Club-wide, no team |
+| Trainer `team` field | Required at account creation | Dropped |
+| Player schedule | Own team only (`schedule/page.tsx:16`) | Whole club |
+| Admin over events | Full control of any team | Unchanged — full override |
+| Club-wide events | Admin-only (`canManageEventTeam`) | Unchanged |
+| Account management | Create only | Create, edit, reset, deactivate |
+| Admin-manages-Admin | Any Admin can create Admins | Super-admins only |
+| Passwords | Admin-set, permanent | Forced change after create/reset |
+| Roster link | Optional, picked from `players.json` | Auto-created, publish-gated |
+| Public content | JSON files, dev-edited | DB-backed, Admin-edited |
+| Attendance | Trainer/Admin mark, player sees own | Unchanged |
+| Attendance reports | None | Trainer + Admin |
+| Fee records | None | Admin sees all, member sees own |
+| Audit log | None | Super-admin only |
+| Guest access | Full public read, names visible | Unchanged |
+
+Two rows are worth calling out because they **reduce** existing access rather
+than extend it — implementing them is a behavior change, not just a feature:
+Trainers gaining club-wide reach removes the team boundary that currently
+exists, and ordinary Admins lose the ability to create fellow Admins.

--- a/docs/roles/admin.md
+++ b/docs/roles/admin.md
@@ -1,0 +1,86 @@
+# Role: Admin
+
+Runs the club's day-to-day operations in the app. `role: "ADMIN"`.
+
+Part of the [Roles & Permissions](../roles-and-permissions.md) specification.
+**Status: specification** — parts are not built yet, see
+[Current vs. target](#current-vs-target).
+
+An Admin without the super-admin flag is what this page describes. For managing
+fellow Admins and reading the audit log, see [Super-admin](super-admin.md).
+
+## Accounts (Players and Trainers)
+
+- **Create** accounts — name, email, temporary password, role, and for Players
+  the auto-created roster entry.
+- **Edit** existing accounts — name, email, role, roster link.
+- **Reset passwords**, issuing a new temporary password. The member is forced
+  to change it on next login.
+- **Deactivate** accounts. Deactivation is a **soft disable**: the member can
+  no longer log in, but their events, attendance history, and roster entry are
+  retained. Club records are never destroyed by a departure.
+
+## Events — full override
+
+- Create, edit, cancel, and delete **any event of any team**, including events
+  a Trainer created. The Admin is the backstop when a Trainer is unavailable.
+- **Club-wide ("both teams") events are Admin-only** — no Trainer may create
+  them.
+- Mark attendance on any session.
+
+## Content — full CMS
+
+Admins manage all public website content from the dashboard:
+
+- News articles
+- Team rosters, including publishing or unpublishing auto-created entries
+- Shop products
+- Club info — mission, motto, values, contact details
+- Membership tiers
+
+This is what moves the site off dev-edited JSON files; see
+[Data model consequences](../roles-and-permissions.md#data-model-consequences).
+
+## Records
+
+- **Attendance reports** across the club — per-player and per-team summaries.
+- **Membership/fee contribution records** for all members: who has paid, when,
+  and what is outstanding.
+
+## Cannot
+
+- Create, edit, promote, demote, or disable **another Admin**. That is
+  super-admin territory, and it is the main limit on this otherwise very broad
+  role.
+- Grant or revoke the **super-admin flag**.
+- View the **audit log** — restricted to super-admins so that ordinary Admin
+  actions remain reviewable by a smaller circle.
+- Hard-delete anything. Removal is always a soft disable.
+
+## Account lifecycle
+
+- **Created** by a super-admin. The first Admin is the bootstrap account
+  created by `prisma/seed.ts`, which also carries the super-admin flag.
+- **Password** is set by the creating super-admin and forced to change on first
+  login.
+- **Carries no `team`** — Admins are club-wide.
+
+## Current vs. target
+
+| | Today | Target |
+|---|---|---|
+| Create accounts | Yes (`src/app/dashboard/users/actions.ts:17`) | Unchanged |
+| Edit accounts | No | Yes |
+| Reset passwords | No | Yes, with forced change |
+| Deactivate accounts | No | Yes, soft disable |
+| Create other Admins | Yes | **No** — super-admin only |
+| Events | Full control, any team | Unchanged |
+| Club-wide events | Admin-only | Unchanged |
+| Public content | JSON files, dev-edited | Full CMS from the dashboard |
+| Attendance reports | Do not exist | Can view |
+| Fee records | Do not exist | Sees all |
+| Audit log | Does not exist | **No access** — super-admin only |
+
+Losing the ability to create fellow Admins is a **reduction** in what the role
+can do today. Implementing it needs the super-admin flag to exist first, or the
+club is left with no one able to add an Admin.

--- a/docs/roles/guest.md
+++ b/docs/roles/guest.md
@@ -1,0 +1,41 @@
+# Role: Guest
+
+Anyone visiting the site without logging in. No account, no session.
+
+Part of the [Roles & Permissions](../roles-and-permissions.md) specification.
+**Status: specification.** Guest is the one role whose target matches what the
+site already does.
+
+## Can
+
+- Read every public page: home, club info, teams, news, training and game
+  schedule, shop, contact.
+- See the public roster — player **names and avatars** for both teams.
+- See training and game times, venues, and opponents.
+
+## Cannot
+
+- See any personal detail beyond a name: no email addresses, no phone numbers,
+  no attendance data, no fee records. The rule is "public, minus personal
+  details" — names themselves stay public.
+- Reach anything under `/dashboard/**`. `src/proxy.ts` redirects to
+  `/login?callbackUrl=…`.
+- Create an account. There is no self-registration; an Admin creates accounts.
+
+## Rules
+
+**Never gate a public page behind login.** The public site is the club's shop
+window and must stay fully readable to a stranger. A new feature that would
+require a visitor to log in to see club information is out of bounds unless
+this document changes first.
+
+**Roster visibility is publish-gated on the other side.** A Guest sees only
+roster entries an Admin has published, so an auto-created entry for a new
+Player account is not exposed until someone decides it should be. See
+[Player](player.md) and [Admin](admin.md).
+
+## Current vs. target
+
+No change. Guests already have full public read access with names visible and
+no personal details exposed. Implementing the rest of this specification must
+not alter that.

--- a/docs/roles/player.md
+++ b/docs/roles/player.md
@@ -1,0 +1,69 @@
+# Role: Player
+
+A club member on a team roster. `role: "PLAYER"`.
+
+Part of the [Roles & Permissions](../roles-and-permissions.md) specification.
+**Status: specification** — parts are not built yet, see
+[Current vs. target](#current-vs-target).
+
+The role is **read-only**. Setting a password when forced to after an Admin
+reset is the single exception.
+
+## Can
+
+- See the **entire club schedule** — both teams' training sessions and games,
+  plus club-wide events. Nothing is hidden between teams; a member may follow
+  the other team's fixtures.
+- See **their own attendance record only**: present, absent, or excused across
+  past sessions.
+- See **their own membership/fee contribution status** — what they have paid
+  and what is outstanding.
+- Set a new password **when forced to** after account creation or an Admin
+  reset.
+
+## Cannot
+
+- See any teammate's attendance, individually or in aggregate.
+- See anyone else's fee records.
+- Mark or RSVP their own attendance. Attendance is the Trainer's record alone;
+  a Player who cannot attend tells the Trainer through the club's existing
+  channels, not through the site.
+- Change their password voluntarily — there is no self-service change page.
+  They ask an Admin for a reset.
+- Edit their own contact details, name, or roster entry.
+- Create, edit, or delete anything: events, accounts, content.
+
+## Roster link
+
+Creating a Player account **auto-creates their roster entry**, so a login and a
+roster record can never drift apart.
+
+The auto-created entry is **hidden from the public site until an Admin
+publishes it**. Real names go on a public website by deliberate act, never as a
+side effect of account creation.
+
+A Player's team follows from their roster entry rather than being set
+independently on the account.
+
+## Account lifecycle
+
+- **Created** by an Admin from `/dashboard/users` — no self-registration.
+- **Password** is set by the Admin as a temporary one and communicated out of
+  band; the Player is forced to change it on first login.
+- **Deactivated** by an Admin as a **soft disable** — they can no longer log
+  in, but their attendance history and roster entry are retained. Nothing is
+  deleted when a member leaves.
+
+## Current vs. target
+
+| | Today | Target |
+|---|---|---|
+| Schedule scope | Own team only (`src/app/dashboard/schedule/page.tsx:16`) | Whole club |
+| Attendance visibility | Own record | Unchanged |
+| Roster link | Optional, picked from `players.json` dropdown | Auto-created, publish-gated |
+| Password | Admin-set, permanent | Forced change on first login and after reset |
+| Fee records | Do not exist | Sees own record |
+| Read-only | Yes | Unchanged |
+
+The roster-link change is the significant one: it requires players to move from
+`src/lib/data/players.json` into a database table with a `published` flag.

--- a/docs/roles/super-admin.md
+++ b/docs/roles/super-admin.md
@@ -1,0 +1,69 @@
+# Role: Super-admin
+
+Not a separate role — a **flag on an Admin account**. `role` stays `"ADMIN"`;
+a boolean marks the holder as a super-admin.
+
+Part of the [Roles & Permissions](../roles-and-permissions.md) specification.
+**Status: specification** — none of this is built yet.
+
+A super-admin holds **every [Admin](admin.md) permission**, plus the three
+below.
+
+## Can, exclusively
+
+- **Manage Admin accounts** — create, edit, demote, or disable a fellow Admin.
+  No ordinary Admin may do this.
+- **Grant the super-admin flag** to another Admin. Multiple super-admins may
+  exist at once, deliberately: the club should never be one lost account away
+  from an unmanageable site.
+- **View the audit log** of admin actions — who created, edited, or disabled
+  which account or event, and when. Restricting this to super-admins keeps
+  ordinary Admins accountable to a smaller circle rather than to no one.
+
+## Where the flag comes from
+
+The bootstrap Administrator created by `prisma/seed.ts` gets the flag
+automatically. From there it spreads only by an existing super-admin granting
+it — there is no self-promotion path and no UI for an ordinary Admin to request
+it.
+
+Granting **copies** the flag rather than moving it; the granting super-admin
+keeps their own. Revoking is possible, and a super-admin may demote another
+super-admin to ordinary Admin.
+
+## Why a flag and not a fourth role
+
+Adding `SUPER_ADMIN` to `ROLES` would mean revisiting every role check in the
+codebase, and every check that currently reads `role === "ADMIN"` would silently
+stop matching the club's most powerful account. A separate boolean leaves all
+existing Admin checks correct and adds a second, narrower check only where the
+three exclusive powers are enforced.
+
+## Lockout considerations
+
+- Because multiple super-admins are allowed, the intended safeguard against
+  losing access is **having more than one**, not a recovery flow. There is no
+  email-based recovery and no self-service escalation.
+- If every super-admin account is lost, recovery means a developer setting the
+  flag directly in the database.
+- Whether a super-admin may disable *themselves* or the last remaining
+  super-admin is **undecided** — the safe implementation refuses to remove the
+  final flag, and that is what should be built unless the club says otherwise.
+
+## Current vs. target
+
+Nothing exists today. Every Admin is equal, any Admin can create another Admin,
+and there is no audit log.
+
+Implementation needs, at minimum:
+
+1. An `isSuperAdmin` boolean on `User`, defaulting to false.
+2. `prisma/seed.ts` setting it on the bootstrap Administrator.
+3. A permission helper alongside `canManageTeam` in `src/lib/auth-helpers.ts`,
+   enforced in the server action — not only on the page.
+4. The Admin-management and audit-log UI gated behind it.
+
+This is the **first thing to build** out of the whole specification: the
+[Admin](admin.md) role loses the ability to create fellow Admins, so without
+the flag in place the club would end up with no one able to add an Admin at
+all.

--- a/docs/roles/trainer.md
+++ b/docs/roles/trainer.md
@@ -1,0 +1,77 @@
+# Role: Trainer
+
+A coach. `role: "TRAINER"`.
+
+Part of the [Roles & Permissions](../roles-and-permissions.md) specification.
+**Status: specification** — parts are not built yet, see
+[Current vs. target](#current-vs-target).
+
+Trainers are **club-wide, not scoped to a team**. Any Trainer may run sessions
+for any team.
+
+## Can
+
+- Create and edit **training sessions** for any team: date, time, venue,
+  address, training plan, notes.
+- Create and edit **games/matches** for any team, including the opponent.
+- **Cancel or delete** events, so a called-off session stops showing on the
+  public site.
+- **Mark attendance** for any session — present, absent, excused, unknown.
+  Attendance is the Trainer's record; players do not self-mark or RSVP.
+- View **attendance reports** — per-player and per-team summaries over a date
+  range, the same figures an Admin sees.
+
+## Cannot
+
+- Create or edit **club-wide ("both teams") events**. Those are Admin-only.
+- Create, edit, disable, or delete **user accounts** of any kind — including
+  Player logins for players they coach.
+- Manage **public content**: no news, no roster editing, no shop, no club info.
+- See **membership or fee records** for anyone.
+- See the **audit log**.
+- See members' **contact details**. A Trainer reaches players through the
+  channels the club already uses, not through the site.
+
+## No team field
+
+Because Trainers are club-wide, a Trainer account carries **no `team` value at
+all**, like an Admin. The account creation form stops asking for one, and no
+permission check consults it.
+
+This is a deliberate widening of the current model, in which a Trainer is
+locked to boys or girls. The trade-off accepted: an absent Trainer's sessions
+can be picked up by any colleague without an Admin reassigning anything.
+
+## Relationship to Admin
+
+Admins hold **full override** on events, including ones a Trainer created —
+they are the backstop when no Trainer is available. Trainers and Admins
+therefore overlap on the schedule; the difference is that Admins additionally
+own accounts, content, fees, and club-wide events, while Trainers own nothing
+outside the schedule and attendance.
+
+## Account lifecycle
+
+- **Created** by an Admin from `/dashboard/users`.
+- **Password** is Admin-set and temporary; forced change on first login.
+- **Deactivated** as a **soft disable** — events they created and attendance
+  they recorded are retained, and the events remain editable by other Trainers
+  and Admins.
+
+## Current vs. target
+
+| | Today | Target |
+|---|---|---|
+| Team scope | One team, enforced by `canManageTeam` (`src/lib/auth-helpers.ts:21`) | Club-wide, any team |
+| `team` field | Required at account creation | Dropped |
+| Training sessions | Create/edit, own team | Create/edit, any team |
+| Games | Create/edit, own team | Create/edit, any team |
+| Cancel/delete events | Own team | Any team |
+| Club-wide events | Blocked (`canManageEventTeam:28`) | Unchanged — still blocked |
+| Attendance marking | Own team | Any team |
+| Attendance reports | Do not exist | Can view |
+| Accounts / content / fees / audit | No access | Unchanged — no access |
+
+Removing team scoping touches `canManageTeam`, `canManageEventTeam`, the
+account creation form and action, and the `NewEventForm` "locked team" pattern
+that currently pairs a disabled `<select>` with a hidden input.


### PR DESCRIPTION
Capture the club's decisions on what Guest, Player, Trainer, Admin, and
super-admin may and may not do, in docs/roles-and-permissions.md:

- Guest: full public read, names visible, no personal details.
- Player: read-only, whole-club schedule, own attendance and own fee
  record only; roster entry auto-created but publish-gated.
- Trainer: club-wide (no team scoping), owns events and attendance,
  no accounts/content/fees; club-wide events stay Admin-only.
- Admin: account create/edit/reset/soft-disable, full event override,
  full CMS over public content, attendance and fee records.
- Super-admin: flag on an Admin account, seeded, transferable to
  others; sole manager of Admin accounts and sole viewer of the audit
  log.

Also records the cross-cutting password and deactivation rules, the
data-model consequences (content moves to the DB, new User fields and
models), and a current-vs-target gap table. Specification only, no code
changes. CLAUDE.md now points at it and flags the headline differences.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017XP5eJvJBZE5HzAfQxL9gV