### PR TITLE
Migrate database from SQLite to Turso (libSQL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,17 @@
 # Copy this file to .env and fill in real values for local development.
 
-# SQLite connection string (file-based, created automatically by `npx prisma migrate dev`)
+# Database connection (libSQL — Turso in production, a local file for dev).
+#
+# Local dev: leave this as a local file, no Turso account needed. Behaves
+# just like plain SQLite, created automatically by `npx prisma migrate dev`.
 DATABASE_URL="file:./dev.db"
+
+# Production/Turso: point at your Turso database instead, e.g.
+#   DATABASE_URL="libsql://<db-name>-<org>.turso.io"
+#   TURSO_AUTH_TOKEN="<token from `turso db tokens create <db-name>`>"
+# Leave TURSO_AUTH_TOKEN unset for local file-based dev — it's ignored when
+# DATABASE_URL is a "file:" URL.
+TURSO_AUTH_TOKEN=""
 
 # Secret used to sign NextAuth (Auth.js) session JWTs.
 # Generate one with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Website for NFC Nürnberg, a hobby football club for the Nepali community in
 Nürnberg, Germany. Next.js (App Router, TypeScript), Tailwind CSS v4, Prisma +
-SQLite, NextAuth (Auth.js) v5.
+libSQL/Turso, NextAuth (Auth.js) v5.
 
 ## Non-negotiables — read before editing
 
@@ -34,7 +34,7 @@ Two data layers, deliberately separate:
    `ClubRepository` interface) — club info, teams, players, news, membership
    tiers, committee roles. Content editors change JSON; if this ever needs a
    real CMS/DB, only `repository.ts`'s implementation changes, not callers.
-2. **Dynamic data** (Prisma + SQLite, `src/lib/db.ts` / `src/lib/events.ts`) —
+2. **Dynamic data** (Prisma + libSQL/Turso, `src/lib/db.ts` / `src/lib/events.ts`) —
    user accounts, training/game events, attendance. This is what the member
    area (`/login`, `/dashboard/**`) reads and writes, and what the public
    `/`, `/training`, and `/contact` pages read (via `listUpcomingEvents`) so
@@ -74,18 +74,27 @@ created by `prisma/seed.ts`; everyone else is created from
   protection lives in `src/proxy.ts`, not `middleware.ts`. Using the old name
   fails silently/confusingly (stale build cache can make it *look* like it's
   working right up until you clear `.next`).
-- **Prisma 7 requires a driver adapter** — `@prisma/adapter-better-sqlite3` +
-  `better-sqlite3`, wired up in `src/lib/db.ts`. The generator is
+- **Prisma 7 requires a driver adapter** — `@prisma/adapter-libsql` +
+  `@libsql/client`, wired up in `src/lib/db.ts`. The generator is
   `prisma-client` (not the old `prisma-client-js`), output to
   `src/generated/prisma` (gitignored, regenerate with `npx prisma generate`
   after any schema change). SQLite has no native enum type — `role`,
   `type`, `status` fields in `prisma/schema.prisma` are plain strings with
   allowed values enforced in `src/lib/auth-types.ts`, not Prisma enums.
-- **`better-sqlite3` needs a matching Node ABI or a C++ toolchain.** On a
-  very new/non-LTS Node version (seen with Node 25 on Windows), there's no
-  prebuilt binary yet and `npm install` fails trying to compile from source
-  without Visual Studio Build Tools. Fix: use Node 22 LTS. Don't "fix" this
-  by ripping out the native dependency.
+- **Database is Turso (libSQL), not a local SQLite file.** `prisma/schema.prisma`'s
+  datasource `provider` stays `"sqlite"` — libSQL is wire-compatible with
+  SQLite, so the schema, migrations, and queries are unchanged from plain
+  SQLite. What actually changes is the connection: `DATABASE_URL` (a
+  `libsql://...` URL) plus `TURSO_AUTH_TOKEN`, read in `src/lib/db.ts`. This
+  is what makes the member area (accounts, events, attendance) safe to
+  deploy to Vercel — serverless functions have an ephemeral, read-only
+  filesystem, so a local SQLite file would lose every write on the next
+  cold start/redeploy; Turso is a real network database instead. Local dev
+  needs no Turso account: leave `DATABASE_URL` as the default
+  `file:./dev.db` in `.env` and libSQL behaves exactly like local SQLite.
+  Point it at a real `libsql://` URL (with `TURSO_AUTH_TOKEN` set) to run
+  against Turso, e.g. for a shared dev database or to reproduce a
+  production-only issue.
 - **Disabled `<select>`/`<input>` elements are not included in FormData on
   submit.** `NewEventForm.tsx`'s team selector is disabled for Trainers
   (locked to their team) and pairs a disabled `<select>` (display only) with

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Website for NFC Nürnberg, a hobby football club for the Nepali community in Nü
 
 Built with Next.js (App Router, TypeScript, Tailwind CSS v4). Club/team/player content lives in `src/lib/data/*.json` behind a repository interface (`src/lib/repository.ts`), so it can be swapped for a real database/admin later without touching page code.
 
-The site also has a member area (`/login`, `/dashboard/**`) with role-based access — Guest (public, no login), Player, Trainer, and Administrator — backed by Prisma + SQLite and NextAuth (Auth.js). Trainers/Admins schedule trainings and games, set training plans, and mark attendance; Players see their team's schedule and their own attendance. Administrators also maintain the club shop, whose products live in the database rather than in JSON so merchandise can be added or hidden without a rebuild.
+The site also has a member area (`/login`, `/dashboard/**`) with role-based access — Guest (public, no login), Player, Trainer, and Administrator — backed by Prisma + Turso (libSQL) and NextAuth (Auth.js). Trainers/Admins schedule trainings and games, set training plans, and mark attendance; Players see their team's schedule and their own attendance. Administrators also maintain the club shop, whose products live in the database rather than in JSON so merchandise can be added or hidden without a rebuild.
 
 > All player names, coach names, the training venue, and contact details currently shown are placeholder content pending real club details — see `CLAUDE.md` for what's fake vs. what's structural.
 
@@ -176,11 +176,27 @@ database but hides it from `/shop`.
 ```bash
 npm install
 cp .env.example .env        # then edit AUTH_SECRET if needed
-npx prisma migrate dev      # creates the local SQLite database
+npx prisma migrate dev      # creates a local libSQL database file (dev.db) — no Turso account needed
 npx prisma db seed          # creates a bootstrap Administrator account (prints its password once)
 npm run dev
 ```
 
 Log in with the printed Administrator credentials at `/login`, then create Player/Trainer accounts from `/dashboard/users`.
+
+The database is [Turso](https://turso.tech) (libSQL, SQLite-compatible) in
+production, so that writes (accounts, events, attendance) survive on
+Vercel's serverless/ephemeral filesystem. Locally, the default
+`DATABASE_URL="file:./dev.db"` in `.env.example` needs no Turso account and
+behaves like plain SQLite. To run against a real Turso database instead
+(e.g. a shared dev database, or reproducing a production-only issue):
+
+```bash
+turso db create nfc-nurnberg-dev             # one-time, needs the Turso CLI + account
+turso db show nfc-nurnberg-dev --url         # -> DATABASE_URL
+turso db tokens create nfc-nurnberg-dev      # -> TURSO_AUTH_TOKEN
+```
+
+Set both in `.env`, then re-run `npx prisma migrate deploy` and
+`npx prisma db seed` against that database.
 
 See `CLAUDE.md` for architecture notes, the auth/role model, and gotchas already hit while building this.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:smoke": "tsx scripts/smoke-test.ts"
   },
   "dependencies": {
-    "@prisma/adapter-better-sqlite3": "^7.9.1",
+    "@libsql/client": "^0.15.15",
+    "@prisma/adapter-libsql": "^7.9.1",
     "@prisma/client": "^7.9.1",
     "bcryptjs": "^3.0.3",
     "next": "16.2.12",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,6 +6,10 @@ generator client {
   output   = "../src/generated/prisma"
 }
 
+// Provider stays "sqlite" even though the actual backend is Turso/libSQL —
+// libSQL is wire-compatible with SQLite, so Prisma's sqlite dialect (and
+// these migrations) work unchanged. The libSQL driver adapter in
+// src/lib/db.ts is what actually points at Turso vs. a local file.
 datasource db {
   provider = "sqlite"
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,13 +1,17 @@
 import { PrismaClient } from "@/generated/prisma/client";
-import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { PrismaLibSQL } from "@prisma/adapter-libsql";
 
 declare global {
   var __prisma: PrismaClient | undefined;
 }
 
 function createPrismaClient() {
-  const adapter = new PrismaBetterSqlite3({
+  // libSQL is SQLite-wire-compatible: a local "file:./dev.db" URL behaves
+  // like plain SQLite for dev, while a "libsql://..." URL + authToken talks
+  // to a remote Turso database in production. See CLAUDE.md's Turso gotcha.
+  const adapter = new PrismaLibSQL({
     url: process.env.DATABASE_URL ?? "file:./dev.db",
+    authToken: process.env.TURSO_AUTH_TOKEN,
   });
   return new PrismaClient({ adapter });
 }


### PR DESCRIPTION
## Summary

- Swaps `@prisma/adapter-better-sqlite3` for `@prisma/adapter-libsql` + `@libsql/client` in `src/lib/db.ts` so the app can run against Turso in production instead of a local SQLite file, which doesn't survive Vercel's ephemeral serverless filesystem.
- `prisma/schema.prisma` datasource provider stays `"sqlite"` (libSQL is wire-compatible), so no schema/migration changes.
- `.env.example`, `CLAUDE.md`, `README.md` updated for the new `DATABASE_URL`/`TURSO_AUTH_TOKEN` setup; local dev still defaults to a zero-setup `file:./dev.db` libSQL file.

## Not done in this PR (needs follow-up)

- `package-lock.json` was NOT regenerated - run `npm install` locally before merging.
- `npm run build && npm run lint` and `npm run test:smoke` were not run (no npm permissions in the agent session) - please run locally.
- No real Turso database/auth token was created, and Vercel env vars were not set - both need dashboard/CLI access outside this agent's reach.

Closes #12.

🤖 Generated with [Claude Code](https://claude.ai/code)