### PR TITLE
Add multi-role accounts, fee record shape, and audit log scope to roles spec

### DIFF
--- a/docs/roles-and-permissions.md
+++ b/docs/roles-and-permissions.md
@@ -18,6 +18,10 @@ disagree, this is the intent and the code is the backlog.
 | [Admin](roles/admin.md) | Runs the club. Accounts, event override, full CMS, records. |
 | [Super-admin](roles/super-admin.md) | Flag on an Admin. Manages Admins, holds the audit log. |
 
+An account is not locked to a single role — a person can hold any combination
+at once (a playing coach is Player + Trainer). See
+[Multi-role accounts](#multi-role-accounts) below.
+
 ## Permission matrix
 
 | | Guest | Player | Trainer | Admin | Super-admin |
@@ -71,6 +75,58 @@ Page-level role checks are UX — they keep the wrong buttons off the screen. Th
 permission independently. Every rule in this specification must hold even if a
 user hand-crafts a request.
 
+### Multi-role accounts
+
+An account is not locked to a single role. A person can hold any combination
+at once — most commonly Player + Trainer (a playing coach), but Player +
+Admin or Trainer + Admin are equally valid. `role` is a **set**, not a single
+value.
+
+- **Permissions union**: an account's abilities are the union of every role it
+  holds. Holding a broader role does not remove the narrower role's own
+  view — a Player+Trainer still has their own roster entry and personal
+  attendance record, in addition to full club-wide Trainer powers.
+- **Broader supersedes narrower**: where a role's restriction would
+  contradict a permission granted by another role on the same account (e.g.
+  "Players cannot see teammates' attendance" vs. Trainer's attendance
+  reports), the broader permission wins. The restriction is a ceiling for
+  accounts that hold *only* the narrower role, not an active limit imposed on
+  everyone who happens to also hold it.
+- **Super-admin still requires Admin** in the role set — it is not a role of
+  its own and cannot attach to a Player- or Trainer-only account. See
+  [Super-admin](roles/super-admin.md).
+- **Adding Player to an existing account** auto-creates a roster entry, the
+  same as creating a fresh Player account (see [Player](roles/player.md)).
+- **Removing Player from a multi-role account** unpublishes but retains the
+  roster entry — consistent with soft-disable elsewhere, no history is lost.
+
+This is a different concept from the cumulative-permissions note in the
+matrix above: that note is about the matrix reading additively (an Admin
+check doesn't assume superiority over a Trainer check), while this section is
+about one account literally holding more than one role label at once.
+
+### Membership/fee records
+
+Recorded by manual Admin entry — there is no payment processor integration.
+Each contribution carries an **amount**, a **date**, and the **period/tier**
+it covers. "Outstanding" is not entered by hand: it is computed as the
+tier's fee amount minus the contributions recorded for that period, so an
+Admin only ever enters what was actually paid. This requires each
+membership tier to carry a fee amount, which `membership-tiers.json` does
+not today.
+
+A Player sees an itemized list of their own contributions (not just a
+paid/outstanding summary); an Admin sees the same for every member.
+
+### Audit log
+
+Covers every mutation an Admin or super-admin can make — accounts, events,
+content, and fee records — including super-admins' own actions; nothing is
+exempted. Each entry is a simple record of who did what to what target and
+when. It does not store a before/after diff of the changed values. Entries
+are retained indefinitely. Restricted to super-admins to read; see
+[Super-admin](roles/super-admin.md).
+
 ---
 
 ## Data model consequences
@@ -88,11 +144,21 @@ not yet support:
    visibility and a relation to the `User` who owns the login.
 3. **`User.team` is dropped for Trainers** (club-wide) and is meaningful only
    for Players, whose team follows their roster entry.
-4. **New `User` fields**: `isSuperAdmin`, `isActive` (soft disable), and
+4. **`User.role` becomes a set, not a single value.** An account can hold any
+   combination of Player/Trainer/Admin (e.g. a playing coach is Player +
+   Trainer). This replaces the current single-string `role` column — likely a
+   join table or a small array column — and every `role === "X"` check in the
+   codebase becomes a "does the set contain X" check. See
+   [Multi-role accounts](#multi-role-accounts).
+5. **New `User` fields**: `isSuperAdmin`, `isActive` (soft disable), and
    `mustChangePassword` (forced reset flow).
-5. **New models**: membership/fee contributions, and an audit log of admin
-   actions.
-6. **Attendance** keeps its `playerSlug` link but points at the `Player` table
+6. **New models**: membership/fee contributions (amount, date, tier/period
+   reference), and an audit log of admin actions (actor, action, target,
+   timestamp — no diff). See [Membership/fee records](#membershipfee-records)
+   and [Audit log](#audit-log).
+7. **`MembershipTier` gains a fee amount.** `membership-tiers.json` today has
+   no price field; computing "outstanding" requires one per tier.
+8. **Attendance** keeps its `playerSlug` link but points at the `Player` table
    rather than a JSON file.
 
 ---
@@ -104,21 +170,22 @@ Per-role detail lives on each role page.
 
 | Area | Today | Target |
 |---|---|---|
-| Roles | `PLAYER`, `TRAINER`, `ADMIN` | Same three + super-admin flag |
+| Roles | Single value: `PLAYER`, `TRAINER`, or `ADMIN` | A set — any combination, plus super-admin flag on Admin |
 | Trainer scope | Scoped to one team (`canManageTeam`) | Club-wide, no team |
 | Trainer `team` field | Required at account creation | Dropped |
 | Player schedule | Own team only (`schedule/page.tsx:16`) | Whole club |
 | Admin over events | Full control of any team | Unchanged — full override |
 | Club-wide events | Admin-only (`canManageEventTeam`) | Unchanged |
-| Account management | Create only | Create, edit, reset, deactivate |
+| Account management | Create only | Create, edit (incl. role set), reset, deactivate |
 | Admin-manages-Admin | Any Admin can create Admins | Super-admins only |
 | Passwords | Admin-set, permanent | Forced change after create/reset |
-| Roster link | Optional, picked from `players.json` | Auto-created, publish-gated |
+| Roster link | Optional, picked from `players.json` | Auto-created/removed as Player role is added/removed, publish-gated |
 | Public content | JSON files, dev-edited | DB-backed, Admin-edited |
+| Membership tiers | No fee amount | Fee amount per tier |
 | Attendance | Trainer/Admin mark, player sees own | Unchanged |
 | Attendance reports | None | Trainer + Admin |
-| Fee records | None | Admin sees all, member sees own |
-| Audit log | None | Super-admin only |
+| Fee records | None | Manual entry; Admin sees all, member sees own itemized, outstanding auto-computed |
+| Audit log | None | Covers accounts, events, content, and fee-record changes (incl. super-admin actions); super-admin only can view |
 | Guest access | Full public read, names visible | Unchanged |
 
 Two rows are worth calling out because they **reduce** existing access rather
@@ -130,11 +197,15 @@ exists, and ordinary Admins lose the ability to create fellow Admins.
 
 1. **Super-admin flag** — must land before Admins lose Admin-management, or
    nobody can add an Admin. See [Super-admin](roles/super-admin.md).
-2. **`User` field additions** (`isActive`, `mustChangePassword`) and the
-   account edit/reset/disable UI — additive, no content migration needed.
+2. **Multi-role account model** — `User.role` becomes a set. This is a schema
+   and auth-helpers foundation change that every later step touches, so it
+   should land before the team-scoping and content work below, alongside the
+   other `User` field additions (`isActive`, `mustChangePassword`) and the
+   account edit/reset/disable UI.
 3. **Trainer de-scoping** — removes `team` checks, touches forms and helpers.
 4. **Player schedule widening** — a one-line scope change plus tests.
 5. **Content migration to the DB** — the largest piece; unblocks roster
-   auto-create, publish gating, and the CMS.
+   auto-create, publish gating, the CMS, and membership tier fee amounts.
 6. **Attendance reports, fee records, audit log** — new features on top of the
-   migrated model.
+   migrated model. The audit log should be scoped to cover content and fee
+   mutations from the start, not bolted on later.

--- a/docs/roles/admin.md
+++ b/docs/roles/admin.md
@@ -44,8 +44,15 @@ This is what moves the site off dev-edited JSON files; see
 ## Records
 
 - **Attendance reports** across the club — per-player and per-team summaries.
-- **Membership/fee contribution records** for all members: who has paid, when,
-  and what is outstanding.
+- **Membership/fee contribution records** for all members, entered manually
+  — amount, date, and period/tier per contribution. Outstanding is computed
+  automatically from the tier's fee, not entered by hand. Sees an itemized
+  view per member, the same shape a member sees for themselves.
+
+## Multi-role
+
+An Admin account can also hold Trainer and/or Player roles — see
+[Multi-role accounts](../roles-and-permissions.md#multi-role-accounts).
 
 ## Cannot
 
@@ -54,7 +61,9 @@ This is what moves the site off dev-edited JSON files; see
   role.
 - Grant or revoke the **super-admin flag**.
 - View the **audit log** — restricted to super-admins so that ordinary Admin
-  actions remain reviewable by a smaller circle.
+  actions remain reviewable by a smaller circle. Every action in this
+  document (accounts, events, content, fee records) is still written to that
+  log — this Admin simply can't read it back.
 - Hard-delete anything. Removal is always a soft disable.
 
 ## Account lifecycle
@@ -78,8 +87,9 @@ This is what moves the site off dev-edited JSON files; see
 | Club-wide events | Admin-only | Unchanged |
 | Public content | JSON files, dev-edited | Full CMS from the dashboard |
 | Attendance reports | Do not exist | Can view |
-| Fee records | Do not exist | Sees all |
-| Audit log | Does not exist | **No access** — super-admin only |
+| Fee records | Do not exist | Sees all, itemized; manual entry, outstanding auto-computed |
+| Audit log | Does not exist | Covers accounts, events, content, and fees (incl. super-admin actions) — **no access** to read it, super-admin only |
+| Roles | Single role only | Can combine with Trainer/Player |
 
 Losing the ability to create fellow Admins is a **reduction** in what the role
 can do today. Implementing it needs the super-admin flag to exist first, or the

--- a/docs/roles/player.md
+++ b/docs/roles/player.md
@@ -16,8 +16,9 @@ reset is the single exception.
   the other team's fixtures.
 - See **their own attendance record only**: present, absent, or excused across
   past sessions.
-- See **their own membership/fee contribution status** — what they have paid
-  and what is outstanding.
+- See **their own membership/fee contributions, itemized** — amount, date,
+  and period/tier for each entry, plus an outstanding total computed
+  automatically from their tier's fee (not entered by hand).
 - Set a new password **when forced to** after account creation or an Admin
   reset.
 
@@ -45,6 +46,21 @@ side effect of account creation.
 A Player's team follows from their roster entry rather than being set
 independently on the account.
 
+## Multi-role
+
+A Player account can also hold Trainer and/or Admin roles at once — e.g. a
+playing coach. See
+[Multi-role accounts](../roles-and-permissions.md#multi-role-accounts) for
+the general rules. The practical effect for a Player: their own roster
+entry, personal schedule view, and personal attendance/fee record described
+above stay theirs regardless of what other roles they also hold — a
+Player+Trainer still sees their own attendance the way any Player does, in
+addition to the club-wide Trainer powers on top.
+
+Adding the Player role to an existing Trainer/Admin account auto-creates a
+roster entry, same as a fresh Player signup. Removing Player from a
+multi-role account unpublishes but retains that roster entry.
+
 ## Account lifecycle
 
 - **Created** by an Admin from `/dashboard/users` — no self-registration.
@@ -62,8 +78,9 @@ independently on the account.
 | Attendance visibility | Own record | Unchanged |
 | Roster link | Optional, picked from `players.json` dropdown | Auto-created, publish-gated |
 | Password | Admin-set, permanent | Forced change on first login and after reset |
-| Fee records | Do not exist | Sees own record |
+| Fee records | Do not exist | Sees own itemized record, outstanding auto-computed |
 | Read-only | Yes | Unchanged |
+| Roles | Single role only | Can combine with Trainer/Admin |
 
 The roster-link change is the significant one: it requires players to move from
 `src/lib/data/players.json` into a database table with a `published` flag.

--- a/docs/roles/super-admin.md
+++ b/docs/roles/super-admin.md
@@ -16,9 +16,12 @@ below.
 - **Grant the super-admin flag** to another Admin. Multiple super-admins may
   exist at once, deliberately: the club should never be one lost account away
   from an unmanageable site.
-- **View the audit log** of admin actions — who created, edited, or disabled
-  which account or event, and when. Restricting this to super-admins keeps
-  ordinary Admins accountable to a smaller circle rather than to no one.
+- **View the audit log** of admin actions — covering every mutation an Admin
+  or super-admin can make: accounts, events, content, and fee records,
+  including super-admins' own actions. Each entry is a simple
+  who/action/target/when record (no before/after diff), retained
+  indefinitely. Restricting read access to super-admins keeps ordinary
+  Admins accountable to a smaller circle rather than to no one.
 
 ## Where the flag comes from
 
@@ -30,6 +33,11 @@ it.
 Granting **copies** the flag rather than moving it; the granting super-admin
 keeps their own. Revoking is possible, and a super-admin may demote another
 super-admin to ordinary Admin.
+
+This is unrelated to
+[multi-role accounts](../roles-and-permissions.md#multi-role-accounts): an
+account's `role` set (Player/Trainer/Admin) and the `isSuperAdmin` flag are
+independent concepts, but the flag still requires Admin present in that set.
 
 ## Why a flag and not a fourth role
 
@@ -46,9 +54,10 @@ three exclusive powers are enforced.
   email-based recovery and no self-service escalation.
 - If every super-admin account is lost, recovery means a developer setting the
   flag directly in the database.
-- Whether a super-admin may disable *themselves* or the last remaining
-  super-admin is **undecided** — the safe implementation refuses to remove the
-  final flag, and that is what should be built unless the club says otherwise.
+- A super-admin may **not** disable or demote themselves, nor disable or
+  demote the last remaining super-admin, if doing so would leave zero
+  super-admins. This applies whether it's self-demotion or removing the last
+  other one — the flag can never hit zero holders through normal use.
 
 ## Current vs. target
 
@@ -62,6 +71,9 @@ Implementation needs, at minimum:
 3. A permission helper alongside `canManageTeam` in `src/lib/auth-helpers.ts`,
    enforced in the server action — not only on the page.
 4. The Admin-management and audit-log UI gated behind it.
+5. An audit log model (actor, action, target, timestamp) written on every
+   Admin/super-admin mutation across accounts, events, content, and fee
+   records.
 
 This is the **first thing to build** out of the whole specification: the
 [Admin](admin.md) role loses the ability to create fellow Admins, so without

--- a/docs/roles/trainer.md
+++ b/docs/roles/trainer.md
@@ -40,7 +40,20 @@ permission check consults it.
 
 This is a deliberate widening of the current model, in which a Trainer is
 locked to boys or girls. The trade-off accepted: an absent Trainer's sessions
-can be picked up by any colleague without an Admin reassigning anything.
+can be picked up by any colleague without an Admin reassigning anything. It
+also means two Trainers can edit or cancel the same event: this is
+**silent last-write-wins**, with no conflict warning, edit history, or
+notification to the Trainer who made the earlier change — the same trade-off
+as above, just applied to concurrent edits instead of absence.
+
+## Multi-role
+
+A Trainer account can also hold Player and/or Admin roles — see
+[Multi-role accounts](../roles-and-permissions.md#multi-role-accounts).
+Trainer+Admin is permitted but largely redundant, since Admin already
+includes full event override. Trainer+Player (a playing coach) keeps their
+own roster entry and personal attendance view in addition to full club-wide
+Trainer powers.
 
 ## Relationship to Admin
 
@@ -71,6 +84,7 @@ outside the schedule and attendance.
 | Attendance marking | Own team | Any team |
 | Attendance reports | Do not exist | Can view |
 | Accounts / content / fees / audit | No access | Unchanged — no access |
+| Roles | Single role only | Can combine with Player/Admin |
 
 Removing team scoping touches `canManageTeam`, `canManageEventTeam`, the
 account creation form and action, and the `NewEventForm` "locked team" pattern


### PR DESCRIPTION
## Summary
- Accounts can now hold more than one role at once (e.g. a playing coach is Player + Trainer) — permissions union, broader role supersedes narrower restrictions, super-admin flag still requires Admin in the set.
- Membership/fee contributions are manually entered (amount, date, period/tier); outstanding is auto-computed from the tier's fee, which means `MembershipTier` now needs a fee amount field it doesn't have today.
- Audit log scope widened to cover every Admin/super-admin mutation (accounts, events, content, fee records), not just accounts/events, and explicitly includes super-admins' own actions.
- Firms up the previously "undecided" super-admin self-lockout rule: no action may leave zero super-admins.

Settled via a `/grill-me` session stress-testing `docs/roles-and-permissions.md`; this is a documentation-only change to the target spec, no application code touched.

## Test plan
- [x] Read back all five edited files for internal consistency (no leftover "undecided" language, cross-links resolve)
- [x] Confirmed `docs/roles/guest.md` is untouched (nothing decided affects Guest)
- N/A — docs-only change, no build/lint/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)