### PR TITLE
Split site features into per-capability requirement docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# NFC Nürnberg Club Website
+
+The domain context for the club website: a Next.js site with public pages, a member dashboard, and (per `docs/roles-and-permissions.md`) a target permissions model this project is being built toward.
+
+## Language
+
+**Feature (Capability)**:
+A cohesive slice of user-facing behavior spanning whatever pages/roles touch it (e.g. Event Scheduling & Attendance spans a public page and a dashboard page). The unit that requirement documents are split by.
+_Avoid_: Page, module, area — those describe *where* code lives, not the capability itself.
+
+**Requirement document**:
+A markdown spec in `docs/features/`, one per capability, written PRD-style (problem statement, user stories, acceptance criteria, out-of-scope) plus a current-vs-target table. Feeds — but is not itself — a set of GitHub issues.
+_Avoid_: Spec (too generic — this repo also has role specs), PRD (implies a stricter/external template than what's used here).
+
+**Workitem**:
+A GitHub issue filed in `upretiraman/playgroundNFC`, matching the repo's existing branch-per-issue / PR-per-issue workflow.
+_Avoid_: Ticket, task (not tied to a concrete system in this repo).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,66 @@
+# Feature Requirement Documents
+
+An index of the site's capabilities, each documented separately in
+`docs/features/` so it can be turned into GitHub issues independently of the
+others. Companion to [docs/roles-and-permissions.md](roles-and-permissions.md),
+which stays the single source of truth for **who can do what** — these
+documents describe **what each capability does** and reference the roles
+spec rather than repeating its matrix. See [CONTEXT.md](../CONTEXT.md) for
+the vocabulary used across all of them (Feature/Capability, Requirement
+document, Workitem).
+
+## The capabilities
+
+| Capability | Summary | Status |
+|---|---|---|
+| [Public Content & Static Info](features/public-content.md) | Home, Club, Contact — mission, values, committee, membership tier descriptions | Live, JSON-backed |
+| [News](features/news.md) | Article listing + detail pages | Live, JSON-backed |
+| [Teams & Player Rosters](features/teams-and-rosters.md) | Team/roster browsing, player profiles | Live browsing; roster auto-create/publish-gating is target only |
+| [Shop](features/shop.md) | Public merchandise browsing + Admin catalog management | Live, fully built, previously undocumented |
+| [Auth & Account Access](features/auth-and-account-access.md) | Sign-in, session/route protection, forced password change | Live sign-in; forced reset is target only |
+| [Event Scheduling & Attendance](features/event-scheduling-and-attendance.md) | Training/game scheduling, attendance marking, public schedule | Live; Trainer de-scoping and Player schedule widening are target only |
+| [Account Management](features/account-management.md) | Admin creates/edits/resets/disables other members' accounts; multi-role; super-admin flag | Create-only is live; everything else is target only |
+| [Membership & Fee Records](features/membership-and-fees.md) | Manual contribution entry, auto-computed outstanding balance | Not built |
+| [Audit Log](features/audit-log.md) | Who-did-what-to-what-when across every Admin/super-admin mutation | Not built |
+
+## Suggested build order
+
+This sequences work **across** the capabilities above; each document's own
+"Proposed issues" section sequences the work **within** it. It follows the
+dependency chain already laid out in
+[docs/roles-and-permissions.md](roles-and-permissions.md#suggested-build-order),
+expanded to cover the capabilities that spec doesn't itself track (Shop,
+News, Public Content migration).
+
+1. **Super-admin flag** ([Account Management](features/account-management.md)) —
+   must land before Admins lose the ability to create fellow Admins, or
+   nobody can add an Admin at all.
+2. **Multi-role account model** ([Account Management](features/account-management.md)) —
+   `User.role` becomes a set, plus `isActive` and `mustChangePassword`. This
+   is the schema foundation that steps 3–7 below all touch.
+3. **Forced password change flow** ([Auth & Account Access](features/auth-and-account-access.md)) —
+   depends on `mustChangePassword` from step 2.
+4. **Trainer de-scoping and Player schedule widening**
+   ([Event Scheduling & Attendance](features/event-scheduling-and-attendance.md)) —
+   depends on the `User.team` changes from step 2.
+5. **Player/roster auto-create and publish-gating**
+   ([Teams & Player Rosters](features/teams-and-rosters.md)) — depends on
+   the multi-role model from step 2.
+6. **Content migration to the database** ([Public Content & Static Info](features/public-content.md),
+   [News](features/news.md)) — the largest single piece of work; mostly
+   independent of steps 1–5, so it can run in parallel with them rather
+   than strictly after. Unblocks the CMS and membership tier fee amounts.
+7. **Shop permissions clarification** ([Shop](features/shop.md)) — no
+   dependencies, low effort; slot in wherever convenient.
+8. **Membership & fee records** ([Membership & Fee Records](features/membership-and-fees.md)) —
+   depends on step 2 (stable member reference) and step 6 (`MembershipTier`
+   gaining a fee amount).
+9. **Audit log** ([Audit Log](features/audit-log.md)) — depends on steps
+   2, 4, 5, 6, and 8 existing as write paths to wire into. Scope it to
+   cover content and fee mutations from the start rather than adding those
+   later, per the roles spec.
+
+Two steps are worth calling out because they **reduce** existing access
+rather than extend it: step 1 removes ordinary Admins' ability to create
+fellow Admins, and step 4 removes the team boundary that currently scopes
+Trainers. Both are intentional behavior changes, not side effects.

--- a/docs/features/account-management.md
+++ b/docs/features/account-management.md
@@ -1,0 +1,126 @@
+# Account Management
+
+An Admin's control over everyone else's accounts: creating, editing,
+resetting, and deactivating Player/Trainer/Admin logins, plus the
+super-admin flag that gates Admin-on-Admin management. This is the
+foundation the roles specification's suggested build order puts first —
+almost every other capability's target state depends on the multi-role
+`User.role` set landing here. Distinct from
+[Auth & Account Access](./auth-and-account-access.md), which is a member
+acting on their *own* session.
+
+**Status**: Create-only exists today. Edit, reset, deactivate, multi-role,
+and the super-admin flag are all target only.
+
+## User stories
+
+- As an **Admin**, I want to create Player, Trainer, or Admin accounts with
+  a temporary password, so new members and coaches get access.
+- As an **Admin**, I want to edit an existing account (name, email, role
+  set), so I can fix mistakes or reflect a real change without deleting and
+  recreating the account.
+- As an **Admin**, I want to reset a member's password, issuing a new
+  temporary one they're forced to change on next login, so I can help
+  someone locked out without emailing them a permanent password.
+- As an **Admin**, I want to deactivate (not delete) an account when
+  someone leaves the club, so their event/attendance/roster history stays
+  intact.
+- As an **Admin**, I want to grant an account more than one role (e.g. a
+  playing coach gets both Player and Trainer), so one person doesn't need
+  two logins.
+- As a **super-admin**, I want to be the only one who can create, edit,
+  disable, or promote a fellow Admin, so the club's most powerful role
+  isn't self-managing.
+- As a **super-admin**, I want to grant or revoke the super-admin flag on
+  another Admin, so the club is never one lost account away from an
+  unmanageable site.
+
+## Acceptance criteria
+
+- Creating an account already works for a single role (`createUser` in
+  `src/app/dashboard/users/actions.ts`); the target adds: editing an
+  existing account, resetting its password (sets `mustChangePassword`, see
+  [Auth & Account Access](./auth-and-account-access.md)), and deactivating
+  it.
+- `role` becomes a **set** — an account can hold any combination of
+  Player/Trainer/Admin. Every `role === "X"` check in the codebase becomes
+  a "does the set contain X" check. See
+  [Multi-role accounts](../roles-and-permissions.md#multi-role-accounts).
+- Adding Player to an account's role set auto-creates its roster entry
+  (unpublished); removing Player unpublishes but retains it — see
+  [Teams & Player Rosters](./teams-and-rosters.md).
+- Deactivation is a **soft disable** everywhere: the account can no longer
+  authenticate, but nothing it created or is linked to is deleted.
+- An `isSuperAdmin` boolean gates: creating/editing/disabling/promoting
+  **other Admins**, and granting/revoking the super-admin flag itself. An
+  ordinary Admin cannot do any of the three, even via a hand-crafted
+  request — the server action re-checks, not just the page.
+- A super-admin cannot demote or disable themselves, nor the last remaining
+  super-admin, if doing so would leave zero super-admins.
+- Every mutation this document describes is written to the
+  [Audit Log](./audit-log.md) — implement the write path alongside each
+  action rather than bolting it on afterward, even though only a
+  super-admin can read the log back.
+
+## Out of scope
+
+- The forced-password-change screen itself (the member-facing flow) — see
+  [Auth & Account Access](./auth-and-account-access.md); this document only
+  covers the Admin triggering a reset.
+- Reading the audit log — see [Audit Log](./audit-log.md); this document
+  only covers writing to it.
+- Self-registration — still none, by design.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Create accounts | Yes, single role | Unchanged, but role becomes a set |
+| Edit accounts | No | Yes (name, email, role set) |
+| Reset passwords | No | Yes, forces change on next login |
+| Deactivate accounts | No | Yes, soft disable |
+| Admin-manages-Admin | Any Admin can create Admins | Super-admin only |
+| Roles | Single value | A set — any combination, plus the `isSuperAdmin` flag |
+| Roster auto-create | N/A | Adding Player role auto-creates a `Player` row |
+| `User.team` | Required for Player/Trainer at creation | Meaningful only for Players (follows roster entry); dropped for Trainers |
+
+## Data model changes
+
+- `User.role` moves from a single string to a set — likely a join table or
+  a small array column; every `role === "X"` check across the codebase
+  becomes a "set contains X" check.
+- New `User` fields: `isSuperAdmin: Boolean` (default `false`,
+  `prisma/seed.ts`'s bootstrap Admin gets `true`), `isActive: Boolean`
+  (soft disable), `mustChangePassword: Boolean` (see
+  [Auth & Account Access](./auth-and-account-access.md)).
+- `User.team` is dropped for Trainers (club-wide, see
+  [Event Scheduling & Attendance](./event-scheduling-and-attendance.md))
+  and becomes meaningful only for Players, whose team follows their roster
+  entry rather than being set independently.
+- New permission helper alongside `canManageTeam` in
+  `src/lib/auth-helpers.ts` enforcing the `isSuperAdmin` checks, called from
+  the server action layer, not only the page.
+- This is the **schema foundation** every later capability in the roles
+  spec touches — see the suggested build order in
+  [docs/features.md](../features.md).
+
+## Permissions
+
+Authoritative rule lives in
+[docs/roles-and-permissions.md](../roles-and-permissions.md),
+[docs/roles/admin.md](../roles/admin.md), and
+[docs/roles/super-admin.md](../roles/super-admin.md) — this document does
+not restate the matrix, only the acceptance criteria that follow from it.
+
+## Proposed issues
+
+- [ ] **Add `isSuperAdmin` to `User`, set on bootstrap Admin in `prisma/seed.ts`** — must land before anything below that depends on Admins losing Admin-management, per the roles spec's suggested build order.
+- [ ] **Add super-admin permission helper + server-action gating for Admin-on-Admin actions**.
+- [ ] **Convert `User.role` to a set** — schema, every `role === "X"` check, migration for existing single-role rows.
+- [ ] **Add `isActive` and `mustChangePassword` to `User`**.
+- [ ] **Build account edit UI/action** (name, email, role set).
+- [ ] **Build password-reset UI/action** (sets `mustChangePassword`).
+- [ ] **Build account deactivate/reactivate UI/action** (soft disable).
+- [ ] **Wire Player-role-add/remove to roster auto-create/unpublish** — coordinate with [Teams & Player Rosters](./teams-and-rosters.md).
+- [ ] **Drop the `team` field from Trainer account creation** — coordinate with [Event Scheduling & Attendance](./event-scheduling-and-attendance.md).
+- [ ] **Write audit-log entries for every account mutation above** — coordinate with [Audit Log](./audit-log.md) so the model lands before or alongside the first write.

--- a/docs/features/audit-log.md
+++ b/docs/features/audit-log.md
@@ -1,0 +1,92 @@
+# Audit Log
+
+A record of every mutation an Admin or super-admin makes — accounts,
+events, content, and fee records — readable only by super-admins. Exists so
+ordinary Admin actions stay reviewable by a smaller circle, even though the
+site has no self-service undo or version history anywhere else. Nothing in
+this capability exists in code today.
+
+**Status**: Not built. Target only. Depends on nearly every other capability
+existing first, since each one is a source of entries.
+
+## User stories
+
+- As a **super-admin**, I want to see who did what to what, and when, across
+  the whole site's Admin-level actions, so I can review activity without
+  trusting every Admin's account never to be misused.
+- As a **super-admin**, I want my own actions logged too, including
+  super-admin-exclusive ones (managing other Admins, granting the flag), so
+  the log has no blind spot for the most powerful accounts.
+- As an **Admin** (non-super-admin), I want my actions to be logged even
+  though I can't read the log back, so accountability doesn't depend on
+  trusting my own self-report.
+
+## Acceptance criteria
+
+- Every mutation covered by [Account Management](./account-management.md)
+  (create/edit/reset/disable an account, grant/revoke super-admin),
+  [Event Scheduling & Attendance](./event-scheduling-and-attendance.md)
+  (create/edit/cancel an event, mark attendance),
+  [Public Content & Static Info](./public-content.md) /
+  [News](./news.md) / [Teams & Player Rosters](./teams-and-rosters.md)
+  (any CMS edit), and
+  [Membership & Fee Records](./membership-and-fees.md) (record a
+  contribution) writes one audit entry.
+- Each entry records **who** (actor), **what action**, **what target**, and
+  **when** — no before/after diff of changed values.
+- Entries are **retained indefinitely** — no automatic pruning or
+  expiration.
+- Reading the log is restricted to accounts with `isSuperAdmin: true`; an
+  ordinary Admin gets no UI entry point and the underlying query is denied
+  server-side if attempted directly.
+- Nothing is exempted — a super-admin's own actions appear in the log they
+  can read, including actions only a super-admin can take.
+
+## Out of scope
+
+- Before/after diffs of changed values — explicitly not part of the
+  target spec; an entry says an edit happened, not what changed.
+- Log export, search UI polish, or filtering beyond what's needed to make
+  an indefinitely-growing log usable — a first pass can be a simple
+  reverse-chronological list; don't over-build this ahead of real usage.
+- Logging Trainer or Player actions — the spec scopes this to Admin/
+  super-admin mutations only; Trainers and Players don't have mutation
+  rights this document would need to cover today.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Audit log | Does not exist | Covers accounts, events, content, and fee-record mutations (incl. super-admin actions) |
+| Diff tracking | N/A | None — who/action/target/when only |
+| Read access | N/A | Super-admin only |
+| Retention | N/A | Indefinite |
+
+## Data model changes
+
+- New Prisma model: audit log entry (actor `User` reference, action
+  string, target type + id, timestamp). No diff/payload field by design.
+- This model should exist **before or alongside** the first write path that
+  needs it — per the roles spec's suggested build order, scope it to cover
+  content and fee mutations from the start rather than bolting those on
+  later once the log already exists for accounts/events.
+- Depends on the `isSuperAdmin` flag from
+  [Account Management](./account-management.md) for the read-permission
+  gate.
+
+## Permissions
+
+Authoritative rule is the "Audit log" cross-cutting section of
+[docs/roles-and-permissions.md](../roles-and-permissions.md) and
+[docs/roles/super-admin.md](../roles/super-admin.md) — this document does
+not restate it beyond the acceptance criteria above.
+
+## Proposed issues
+
+- [ ] **Add an audit log entry Prisma model** (actor, action, target type/id, timestamp).
+- [ ] **Add a shared `logAuditEntry` helper** called from every mutating server action across the other capability docs, so each capability's write path stays a one-line addition rather than a bespoke integration.
+- [ ] **Wire audit writes into Account Management's mutations** (create/edit/reset/disable, super-admin grant/revoke).
+- [ ] **Wire audit writes into Event Scheduling & Attendance's mutations** (create/edit/cancel event, mark attendance).
+- [ ] **Wire audit writes into the CMS mutations** (Public Content, News, Teams & Rosters).
+- [ ] **Wire audit writes into Membership & Fee Records' contribution entry**.
+- [ ] **Build the super-admin-only audit log read view** (reverse-chronological list, no diff).

--- a/docs/features/auth-and-account-access.md
+++ b/docs/features/auth-and-account-access.md
@@ -1,0 +1,86 @@
+# Auth & Account Access
+
+How a member gets into their own account and controls over their own
+session — sign-in, route protection, and the forced-password-change flow.
+Distinct from [Account Management](./account-management.md): this document
+is a member acting on *their own* access; Account Management is an Admin
+acting on *someone else's* account.
+
+**Status**: Sign-in and route protection are live. Forced password change is
+target only — passwords are Admin-set and permanent today.
+
+## User stories
+
+- As a **Player, Trainer, or Admin**, I want to sign in with my email and
+  password, so I can reach the dashboard.
+- As a **Guest**, if I try to reach `/dashboard/**` without signing in, I
+  want to be redirected to `/login` and returned to where I was headed
+  after I sign in, so I don't lose my place.
+- As any member, when an Admin creates my account or resets my password, I
+  want to be forced to set my own new password on my very next login before
+  reaching the dashboard, so the temporary password the Admin gave me out of
+  band doesn't stay valid indefinitely.
+- As any member, I want no "change my password" page outside that forced
+  flow, so there's exactly one, well-understood path to a password change
+  (an Admin resets it) rather than two divergent ones.
+
+## Acceptance criteria
+
+- `/login` accepts email + password; invalid credentials show an error and
+  do not sign in (already implemented via the Credentials provider).
+- Signing in issues a JWT session carrying `role`, `team`, and `playerSlug`
+  (already implemented; see `src/auth.ts`).
+- Any request under `/dashboard/**` without a valid session redirects to
+  `/login?callbackUrl=<original path>` (already implemented via
+  `src/proxy.ts` — **not** `middleware.ts`, see `CLAUDE.md`'s gotchas).
+- Once forced reset ships: a `User` with `mustChangePassword: true` who
+  signs in successfully is routed to a "set new password" screen before any
+  other `/dashboard/**` page is reachable, and cannot navigate around it.
+- After setting a new password, `mustChangePassword` clears and normal
+  dashboard access resumes.
+- There is no page anywhere in the app for a signed-in member to
+  voluntarily change their password outside that forced flow.
+
+## Out of scope
+
+- Self-registration — there is none, by design; not part of this document.
+- Email-based password reset (a "forgot password" link/email flow) — the
+  spec explicitly rules this out; resets are Admin-initiated, not
+  self-service. See [Account Management](./account-management.md) for the
+  Admin side of a reset.
+- Multi-factor authentication — not requested, not in the target spec.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Sign-in | Credentials provider, JWT session | Unchanged |
+| Route protection | `src/proxy.ts`, `/dashboard/:path*` | Unchanged |
+| Password lifecycle | Admin sets it at account creation; permanent | Forced change after account creation or an Admin-initiated reset |
+| Voluntary password change | None | Still none — this is intentional, not a gap |
+
+## Data model changes
+
+- New `User.mustChangePassword: Boolean` field (default `true` on creation,
+  set `true` again on an Admin-triggered reset — see
+  [Account Management](./account-management.md), cleared once the member
+  sets their own password).
+- No changes to the JWT session shape (`SessionUser` in
+  `src/lib/auth-types.ts`) are required by this document alone, though it
+  will also gain fields from the multi-role work — see
+  [Account Management](./account-management.md).
+
+## Permissions
+
+Applies identically to every role once authenticated; Guest access rules
+(never gate a public page behind login) are covered in
+[docs/roles/guest.md](../roles/guest.md). The password-lifecycle rules above
+are the "Passwords" cross-cutting section of
+[docs/roles-and-permissions.md](../roles-and-permissions.md) — this document
+restates them as acceptance criteria but does not change the rule.
+
+## Proposed issues
+
+- [ ] **Add `mustChangePassword` to `User`, default `true` on creation**.
+- [ ] **Build the forced "set new password" screen and route guard** — intercepts `/dashboard/**` navigation while the flag is set.
+- [ ] **Clear `mustChangePassword` on successful password set, redirect to originally requested page**.

--- a/docs/features/event-scheduling-and-attendance.md
+++ b/docs/features/event-scheduling-and-attendance.md
@@ -1,0 +1,104 @@
+# Event Scheduling & Attendance
+
+Training sessions and games/matches: creating and editing them, marking who
+showed up, and surfacing the schedule both publicly (`/training`, home page
+teaser) and to members (`/dashboard/schedule`). The one capability that
+already reads/writes live from Postgres/libSQL rather than JSON, and the one
+with the most current-vs-target movement — team-scoping is being removed
+entirely.
+
+**Status**: Live. Team-scoping (Trainer and Player limited to one team) is
+the current behavior; the target removes it.
+
+## User stories
+
+- As a **Guest**, I want to see upcoming training sessions on `/training`
+  and the home page, split by team, so I know when and where to show up.
+- As a **Trainer**, I want to create a training session or game for any
+  team (not just "my" team), including a training plan, so I'm not blocked
+  from covering for an absent colleague.
+- As a **Trainer**, I want to mark each roster player's attendance
+  (present/absent/excused/unknown) for a session, so there's a record of
+  who showed up.
+- As a **Trainer**, I want to see attendance reports (per-player, per-team,
+  over a date range), so I can spot patterns without re-deriving them by
+  hand.
+- As an **Admin**, I want to create club-wide ("both teams") events that no
+  Trainer can create, so joint sessions have an owner with the authority to
+  schedule them.
+- As a **Player**, I want to see the whole club's schedule (not just my
+  team's), so I can follow the other team's fixtures too.
+- As a **Player**, I want to see only my own attendance history, so my
+  record stays private from teammates.
+
+## Acceptance criteria
+
+- `/training` and the home page teaser show only events from today onward
+  (already implemented via `listUpcomingEvents`), and must stay
+  `force-dynamic` per `CLAUDE.md`'s gotcha about static rendering + live DB
+  data.
+- `/dashboard/schedule` lists events; creating one requires type, team,
+  date, start/end time, venue, address, and (for games) opponent or (for
+  training) a plan; a new event auto-creates an `UNKNOWN` attendance row
+  for every player on the affected team(s) (already implemented).
+- A Trainer can create/edit/cancel events and mark attendance for **any**
+  team, not just one — this is a **behavior change**, not an extension: it
+  removes today's `canManageTeam` team boundary. See
+  [docs/roles/trainer.md](../roles/trainer.md).
+- Club-wide ("both") events remain Admin-only to create — unchanged by the
+  Trainer de-scoping.
+- A Player sees the **whole club's** schedule (today: own team only, per
+  `schedule/page.tsx:16`) but only **their own** attendance record.
+- Attendance reports (per-player/per-team summaries over a date range) are
+  new — Trainer and Admin only, no equivalent exists today.
+- Two Trainers editing/cancelling the same event is **silent
+  last-write-wins** — no conflict warning, no edit history, no notification.
+  This is an accepted trade-off, not a bug to fix as part of this document.
+
+## Out of scope
+
+- Player self-marking or RSVPing to a session — attendance stays the
+  Trainer's record alone, explicitly ruled out in
+  [docs/roles/player.md](../roles/player.md).
+- Event edit history / conflict resolution between Trainers — see the
+  "silent last-write-wins" note above; not addressed here.
+- Recurring/repeating event templates — every event today is created
+  individually; not requested.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Trainer scope | One team, `canManageTeam` (`src/lib/auth-helpers.ts:21`) | Club-wide, any team |
+| Trainer `team` field | Required at account creation | Dropped |
+| Player schedule view | Own team only (`schedule/page.tsx:16`) | Whole club |
+| Player attendance view | Own record | Unchanged |
+| Club-wide events | Admin-only (`canManageEventTeam`) | Unchanged |
+| Attendance reports | Don't exist | Trainer + Admin |
+
+## Data model changes
+
+- No new tables — `Event` and `Attendance` already model everything needed.
+- `canManageTeam` / `canManageEventTeam` in `src/lib/auth-helpers.ts` drop
+  their team-equality check for Trainers (Admin behavior already ignores
+  team). `canManageEventTeam`'s "both" → Admin-only branch is unchanged.
+- Depends on [Account Management](./account-management.md)'s `User.team`
+  removal for Trainers landing in the same wave — see the build order in
+  [docs/features.md](../features.md).
+- Attendance reports are a new read path over existing `Attendance` rows —
+  no schema change, just new queries/UI.
+
+## Permissions
+
+Authoritative rule lives in
+[docs/roles-and-permissions.md](../roles-and-permissions.md),
+[docs/roles/trainer.md](../roles/trainer.md), and
+[docs/roles/player.md](../roles/player.md) — this document does not
+restate the matrix, only the acceptance criteria that follow from it.
+
+## Proposed issues
+
+- [ ] **Drop team-scoping from `canManageTeam`/`canManageEventTeam` for Trainers** — coordinate with the `User.team` schema change in Account Management so both land together.
+- [ ] **Remove the team field from Trainer account creation** (`NewUserForm`, `createUser` action) — coordinate with Account Management.
+- [ ] **Widen Player schedule view to the whole club** — `schedule/page.tsx:16`, a scope change plus tests.
+- [ ] **Build attendance reports** (per-player and per-team, date-range filter) for Trainer + Admin.

--- a/docs/features/membership-and-fees.md
+++ b/docs/features/membership-and-fees.md
@@ -1,0 +1,91 @@
+# Membership & Fee Records
+
+Tracking what each member has actually paid toward their membership tier,
+and computing what they still owe. There is no payment processor —
+contributions are entered by hand by an Admin after money changes hands
+outside the app. Nothing in this capability exists in code today; it's
+entirely new.
+
+**Status**: Not built. Target only.
+
+## User stories
+
+- As an **Admin**, I want to record a contribution (amount, date, which
+  period/tier it covers) for a member, so there's a running record of what
+  they've paid.
+- As an **Admin**, I want to see every member's itemized contribution
+  history and computed outstanding balance, so I can follow up on unpaid
+  dues without doing the arithmetic by hand.
+- As a **Player**, I want to see my own itemized contribution history and
+  outstanding balance, so I know what I've paid and what I still owe.
+- As a **club treasurer** (an Admin holding the Treasurer committee role,
+  per [Public Content & Static Info](./public-content.md)'s roster of
+  roles), I want the outstanding figure to be computed, not manually
+  tracked, so it can't silently drift from reality.
+
+## Acceptance criteria
+
+- Each contribution record carries an amount, a date, and the period/tier
+  it covers — an Admin enters these three fields; nothing else is required.
+- "Outstanding" is **never** entered by hand. It's computed as the tier's
+  fee amount minus the sum of contributions recorded for that period, so an
+  Admin only ever enters what was actually paid.
+- A Player sees an itemized list of **their own** contributions (not a
+  bare paid/outstanding summary) — every individual entry, plus the
+  computed outstanding total.
+- An Admin sees the same itemized view for **every** member.
+- No other role (Guest, Trainer without an Admin role) can see any fee
+  record, for anyone, including their own if they're a Trainer-only
+  account.
+- Every contribution entry an Admin creates is written to the
+  [Audit Log](./audit-log.md).
+
+## Out of scope
+
+- Payment processing / online payment collection — there is deliberately no
+  processor integration; entries are always manual.
+- Editing or deleting a past contribution — not specified either way by
+  `docs/roles-and-permissions.md`; treat as **not supported** in the first
+  pass (append-only) unless the club asks for correction support, since an
+  audited financial record with silent edits is a bigger design question
+  than this document should resolve implicitly.
+- Automated payment reminders/notifications — not requested.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Fee records | Do not exist | Manual entry by Admin; amount, date, period/tier per contribution |
+| Outstanding | N/A | Auto-computed: tier fee minus recorded contributions for the period |
+| Membership tiers | No fee amount (`membership-tiers.json`) | Gains a `feeAmount` field — shared dependency with [Public Content & Static Info](./public-content.md) |
+| Player view | N/A | Own itemized contributions + outstanding |
+| Admin view | N/A | All members' itemized contributions + outstanding |
+
+## Data model changes
+
+- New Prisma model: membership/fee contribution (amount, date, period/tier
+  reference, member reference, recorded-by Admin reference, timestamp).
+- `MembershipTier` gains a `feeAmount` field — this is the **same** schema
+  change called out in [Public Content & Static Info](./public-content.md);
+  land it once, referenced from both documents, not twice.
+- Depends on [Account Management](./account-management.md)'s multi-role
+  `User`/`Player` model being in place, since a contribution needs a stable
+  member reference. See the build order in
+  [docs/features.md](../features.md).
+
+## Permissions
+
+Authoritative rule is the "Membership/fee records" cross-cutting section of
+[docs/roles-and-permissions.md](../roles-and-permissions.md) — own-only for
+Players, all-members for Admin, no access for Guest/Trainer-only. This
+document does not restate it beyond the acceptance criteria above.
+
+## Proposed issues
+
+- [ ] **Add `feeAmount` to `MembershipTier`** — coordinate with [Public Content & Static Info](./public-content.md) so this lands once.
+- [ ] **Add a Prisma model for fee contributions** (amount, date, tier/period, member, recorded-by, timestamp).
+- [ ] **Build the outstanding-balance computation** (tier fee minus recorded contributions for the period).
+- [ ] **Admin dashboard: record a contribution for a member**.
+- [ ] **Admin dashboard: view all members' itemized contributions + outstanding**.
+- [ ] **Player dashboard: view own itemized contributions + outstanding**.
+- [ ] **Write audit-log entries for every contribution recorded** — coordinate with [Audit Log](./audit-log.md).

--- a/docs/features/news.md
+++ b/docs/features/news.md
@@ -1,0 +1,71 @@
+# News
+
+Hand-written articles announcing club milestones, match results, and
+updates — separate from the training/game event system (an event is a
+scheduled session; a news item is a write-up about something that happened
+or was announced). Read-only for everyone but an Admin.
+
+**Status**: Live, content is developer-edited JSON.
+
+## User stories
+
+- As a **Guest**, I want to browse a list of news articles (newest first),
+  so I can catch up on what the club has been doing.
+- As a **Guest**, I want to filter/recognize which team a story is about
+  (boys, girls, or club-wide), so I can find news relevant to the team I
+  follow.
+- As a **Guest**, I want to open a single article and read its full body,
+  so I get the complete story, not just the summary.
+- As an **Admin**, I want to publish, edit, and remove news articles from
+  the dashboard, so club updates don't require a developer and a deploy.
+
+## Acceptance criteria
+
+- `/news` lists every article sorted by date descending, showing date, team
+  badge (if any), title, and summary.
+- `/news/[slug]` renders the full article body for a valid slug; an invalid
+  slug 404s.
+- Home page teaser shows the 3 most recent articles (already implemented).
+- Once Admin publishing ships: a newly published article appears on `/news`
+  without a rebuild; a removed one disappears.
+- Only an Admin can create, edit, or remove articles — Trainers and Players
+  have the same read-only view as Guests.
+
+## Out of scope
+
+- Comments, reactions, or any reader interaction with articles.
+- Rich media beyond a single optional cover image (`coverImage` already
+  exists in the type; this doc doesn't add a gallery or video embed).
+- Auto-generating news from event results — an Admin writes each article by
+  hand, same as today.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Storage | `src/lib/data/news.json` (dev-edited, requires a deploy) | Prisma-backed |
+| Publishing | Developer only, via a JSON commit | Admin, via a dashboard form |
+| Article fields | slug, title, date, summary, body, team?, coverImage? | Unchanged shape |
+
+## Data model changes
+
+- New Prisma `NewsItem` model replacing `news.json`: slug (unique), title,
+  date, summary, body, team (nullable, "boys" \| "girls" \| "both"),
+  coverImage (nullable).
+- `ClubRepository.getNews()` / `getNewsItem()` interface is unchanged; only
+  `JsonClubRepository`'s implementation moves from JSON to Prisma. Callers
+  (`news/page.tsx`, `news/[slug]/page.tsx`, the home page teaser) do not
+  change.
+
+## Permissions
+
+Publishing is Admin-only ("Manage public content (CMS)" in the permission
+matrix). See [docs/roles-and-permissions.md](../roles-and-permissions.md)
+and [docs/roles/admin.md](../roles/admin.md) — this document does not
+restate the rule.
+
+## Proposed issues
+
+- [ ] **Add `NewsItem` Prisma model, migrate off JSON** — schema + migration + repository implementation swap.
+- [ ] **Admin dashboard: news list + create/edit form** — title, date, summary, body, team, cover image.
+- [ ] **Admin dashboard: delete/unpublish a news article**.

--- a/docs/features/public-content.md
+++ b/docs/features/public-content.md
@@ -1,0 +1,95 @@
+# Public Content & Static Info
+
+The Home, Club, and Contact pages — the club's public-facing identity: who it
+is, what it stands for, how it's run, and how to reach it. This is the first
+thing a prospective member or parent sees, so it needs to stay accurate
+without requiring a developer to ship a code change every time club info
+changes (a committee role-holder changes, the mission statement is reworded,
+a phone number changes).
+
+**Status**: Live, content is developer-edited JSON.
+
+## User stories
+
+- As a **Guest**, I want to see the club's mission, values, and founding
+  story on the home page, so I understand what the club is before I decide
+  to reach out.
+- As a **Guest**, I want to see the club's committee structure (who holds
+  which role, what they're responsible for) on the Club page, so I know who
+  to approach for what.
+- As a **Guest**, I want to see the membership tiers (Active / Supporting /
+  Guest-Trial) and what each one entitles me to, so I know what I'm signing
+  up for before I show up.
+- As a **Guest**, I want a Contact page with email, WhatsApp, Instagram, and
+  the next training location, so I have more than one way to get in touch.
+- As an **Admin**, I want to edit club info, committee roles, and membership
+  tier descriptions from the dashboard, so a wording change or a committee
+  reshuffle doesn't require a code deploy.
+
+## Acceptance criteria
+
+- Home page renders club name, motto, founded year, city/country, mission,
+  and values, plus live counts of teams/players and upcoming training
+  sessions (already DB-backed via `listUpcomingEvents`).
+- Club page renders the mission/values banner, a link to the full club
+  protocol PDF, the membership tier table, and the committee roster
+  (title, reports-to, summary, duties) for every entry in the roles content.
+- Contact page renders email (`mailto:`), WhatsApp and Instagram links
+  (only if present), and the venue/address of the next upcoming training
+  session, falling back to a hardcoded venue string when no session exists.
+- Once Admin editing ships: edits to club info / committee roles / tier
+  descriptions are visible on the public pages without a rebuild or deploy.
+- Only an Admin (not a Trainer or Player) can edit this content — see
+  [Permissions](#permissions).
+
+## Out of scope
+
+- Membership **fee amounts**, **contributions**, and **outstanding balance**
+  — that's [Membership & Fee Records](./membership-and-fees.md). This
+  document only covers the public *description* of each tier (what it is,
+  what it includes), which stays visible to Guests.
+- The contact form's delivery mechanism (where a submitted message actually
+  goes) — out of scope for this document; today `ContactForm` is UI-only
+  and this doc doesn't change that.
+- News articles — see [News](./news.md).
+- Team rosters and player profiles — see
+  [Teams & Player Rosters](./teams-and-rosters.md).
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Storage | `src/lib/data/club.json`, `roles.json`, `membership-tiers.json` (dev-edited, requires a deploy) | Prisma-backed, editable from the dashboard |
+| Editing | Developer only, via a JSON commit | Admin, via a CMS form in `/dashboard` |
+| Committee roles | Static list, no photos/contact per role | Unchanged in shape, just DB-backed |
+| Membership tiers | Description only, no fee amount | Gains a fee amount (shared dependency with [Membership & Fee Records](./membership-and-fees.md)) |
+
+## Data model changes
+
+- New Prisma models replacing `club.json`, `roles.json`: a singleton
+  `ClubInfo` record (or a small fixed-row table) and a `ClubRole` table
+  (slug, title, reportsTo, summary, duties).
+- `MembershipTier` becomes a Prisma model (today `membership-tiers.json`);
+  gains a `feeAmount` field. This table is shared with
+  [Membership & Fee Records](./membership-and-fees.md) — land the schema
+  change once, not twice.
+- `src/lib/repository.ts`'s `ClubRepository` interface (`getClubInfo`,
+  `getClubRoles`, `getMembershipTiers`) is unchanged; only
+  `JsonClubRepository`'s implementation moves from JSON reads to Prisma
+  reads. Callers (`page.tsx`, `club/page.tsx`, `contact/page.tsx`) do not
+  change.
+
+## Permissions
+
+Editing is Admin-only ("Manage public content (CMS)" in the permission
+matrix). See [docs/roles-and-permissions.md](../roles-and-permissions.md)
+and [docs/roles/admin.md](../roles/admin.md) for the authoritative rule —
+this document does not restate it.
+
+## Proposed issues
+
+- [ ] **Add `ClubInfo` and `ClubRole` Prisma models, migrate off JSON** — schema + migration + repository implementation swap, no page changes.
+- [ ] **Add `feeAmount` to `MembershipTier` and migrate off JSON** — coordinate with [Membership & Fee Records](./membership-and-fees.md) so this lands once.
+- [ ] **Admin CMS: edit club info** — dashboard form for mission/motto/values/contact fields.
+- [ ] **Admin CMS: manage committee roles** — create/edit/reorder/delete entries.
+- [ ] **Admin CMS: edit membership tier descriptions** — separate from the fee-amount field, which belongs to the fee-records work.

--- a/docs/features/shop.md
+++ b/docs/features/shop.md
@@ -1,0 +1,75 @@
+# Shop
+
+Club merchandise (caps, tote bags, t-shirts) browsable on the public site,
+with an Admin-managed catalog in the dashboard. Fully built already — this
+document exists mainly because **the Shop is not mentioned anywhere in
+`CLAUDE.md` or `docs/roles-and-permissions.md`**, despite being live code
+(`src/app/shop/`, `src/app/dashboard/shop/`, a `Product` Prisma model). This
+doc closes that documentation gap and gives it a home for future issues.
+
+**Status**: Live, including catalog management. No online checkout.
+
+## User stories
+
+- As a **Guest**, I want to browse active products with photos/illustrations,
+  price, colorway, and description, so I can decide what to order.
+- As a **Guest**, I want an "Order" action that takes me to Contact, so I
+  can place an order without an online checkout existing yet.
+- As an **Admin**, I want to add, edit, and delete products, so the catalog
+  reflects what's actually available without a code change.
+- As an **Admin**, I want to mark a product inactive without deleting it, so
+  it disappears from the public shop but its record (and order history, if
+  that's ever added) isn't lost.
+
+## Acceptance criteria
+
+- `/shop` lists only `active: true` products, oldest-created first, each
+  showing image (or CSS illustration fallback via `artVariant`), category,
+  name, description, colorway, and price.
+- `/dashboard/shop` (Admin-only) lists every product regardless of `active`,
+  with visibility, edit, and delete actions.
+- Creating a product requires name, category, price (≥0), colorway,
+  description; slug is derived from name if not supplied and must be unique.
+- Editing and deleting immediately revalidate both `/shop` and
+  `/dashboard/shop` (already implemented via `revalidatePath`).
+
+## Out of scope
+
+- Online checkout / payment processing — "Order" still routes to Contact.
+  This document doesn't add a cart, payment, or order-tracking flow.
+- Inventory/stock-level tracking — `active` is a simple visibility flag, not
+  a stock count.
+- Trainer access to shop management — see the open permissions question
+  below.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Catalog storage | `Product` Prisma model (already DB-backed, unlike every other content type on the site) | Unchanged |
+| Public browsing | Live, active products only | Unchanged |
+| Catalog management | Admin-only (`requireRole(["ADMIN"])` in `actions.ts`) | Unchanged, pending the permissions question below |
+| Checkout | None — "Order" links to Contact | Not addressed by this document; a future capability if the club wants it |
+
+## Data model changes
+
+None — `Product` is already a Prisma model with everything this document's
+acceptance criteria need.
+
+## Permissions
+
+**Open question, not resolved by `docs/roles-and-permissions.md`**: that
+spec's permission matrix has no row for Shop/product management. Code today
+restricts it to Admin only (same as the CMS-flavored permissions for other
+content). Recommendation: treat Shop management as covered by the existing
+"Manage public content (CMS)" Admin permission and add an explicit row to
+`docs/roles-and-permissions.md` confirming that, rather than inventing a
+new permission category — but this needs a decision, not an assumption, since
+Trainers might reasonably want to manage kit/merchandise. Flagged as the
+first proposed issue below.
+
+## Proposed issues
+
+- [ ] **Add Shop to `docs/roles-and-permissions.md`'s permission matrix** — confirm Admin-only is the intended target (or extend to Trainers) before further shop work is scoped.
+- [ ] **(Only if the above resolves to "extend"): widen shop management access** beyond Admin.
+- [ ] **(Future, out of current scope): online checkout** — tracked here only as a placeholder if the club later wants it; not part of this document's acceptance criteria.

--- a/docs/features/teams-and-rosters.md
+++ b/docs/features/teams-and-rosters.md
@@ -1,0 +1,94 @@
+# Teams & Player Rosters
+
+The public face of who plays for NFC Nürnberg: the two squads (boys, girls),
+their coaches, and each player's profile. This is also the capability with
+the biggest data-model change coming — today a roster entry is just a JSON
+row; the target model ties it to a real `User` login and auto-manages it as
+Player accounts are created, edited, or removed.
+
+**Status**: Live (browsing), content is developer-edited JSON. Roster
+auto-create/publish-gating is target only.
+
+## User stories
+
+- As a **Guest**, I want to see both teams with a summary and coach name, so
+  I get a quick overview before drilling into a roster.
+- As a **Guest**, I want to see a full roster for a team (number, position,
+  captain badge), so I can look up a specific player.
+- As a **Guest**, I want to open a player's profile (bio, hometown, joined
+  year, captain status), so I can learn more about them.
+- As an **Admin**, I want a Player account I create to automatically get a
+  roster entry (rather than picking one from a static list), so account
+  creation and roster maintenance are the same action, not two.
+- As an **Admin**, I want a roster entry to stay unpublished until I choose
+  to publish it, so a newly created account doesn't show a half-filled
+  profile to the public before I've added a bio/photo.
+- As an **Admin**, I want removing the Player role from an account to
+  unpublish (not delete) their roster entry, so match history and past
+  profile data aren't lost.
+
+## Acceptance criteria
+
+- `/teams` lists both teams with roster size, description, coach.
+- `/teams/[team]` lists every published player on that team's roster,
+  sorted by squad number.
+- `/teams/[team]/[player]` renders a single player's profile; a mismatched
+  team/player slug pair 404s (already enforced).
+- Home page surfaces captains from both teams (already implemented).
+- Once the target model ships: creating a Player account auto-creates a
+  roster entry linked to that `User`; the entry is unpublished by default
+  and does not appear under `/teams/[team]` until an Admin publishes it.
+- Removing the Player role from a multi-role account unpublishes but does
+  not delete the linked roster entry.
+
+## Out of scope
+
+- Player-editable profiles (a Player editing their own bio/photo) — every
+  role spec today has Players as read-only; this doc doesn't add
+  self-service editing.
+- Real player photos — `PlayerAvatar.tsx`'s generated-initials avatars stay;
+  this doc doesn't add photo upload.
+- Match statistics (goals, appearances) — not part of the current `Player`
+  shape and not requested for this pass.
+
+## Current vs. target
+
+| Area | Today | Target |
+|---|---|---|
+| Storage | `src/lib/data/players.json`, `teams.json` (dev-edited) | `Player` becomes a Prisma table |
+| Roster ↔ account link | `User.playerSlug` optionally picked from a static list at account creation | Auto-created when Player role is added to a `User`; `published` flag drives public visibility |
+| Removing Player role | N/A — role is single-valued today | Unpublishes but retains the roster entry (soft, same pattern as account deactivation) |
+| Teams | `teams.json`, developer-edited | Likely stays low-churn enough to remain JSON, or migrates alongside `Player` — see open question in [Proposed issues](#proposed-issues) |
+
+## Data model changes
+
+- New Prisma `Player` model (replacing `players.json`): slug, team, name,
+  number, position, bio, photoUrl?, joinedYear, hometown?, isCaptain?,
+  `published: Boolean`, and a relation to the `User` that owns the login
+  (`userId`, nullable — a roster entry can exist without a login until an
+  account is created, or vice versa depending on the build order chosen).
+- `User.playerSlug` becomes a real foreign key to `Player.id` instead of a
+  loosely-typed string matched against JSON.
+- Depends on [Account Management](./account-management.md)'s multi-role
+  work landing first — auto-create/unpublish triggers off Player role
+  being added to or removed from a `User`'s role set, which requires
+  `User.role` to already be a set. See the build order in
+  [docs/features.md](../features.md).
+
+## Permissions
+
+Guests/Players/Trainers/Admins all read the same published roster; only an
+Admin publishes/unpublishes entries (bundled into "Manage public content
+(CMS)" plus the account-management flows in
+[docs/roles/admin.md](../roles/admin.md)). See
+[docs/roles-and-permissions.md](../roles-and-permissions.md) for the
+authoritative permission rule.
+
+## Proposed issues
+
+- [ ] **Add `Player` Prisma model with `published` flag, migrate off `players.json`** — schema + migration + repository implementation swap.
+- [ ] **Link `Player` to `User` via foreign key, backfill `playerSlug` matches**.
+- [ ] **Auto-create unpublished `Player` row when Player role is added to an account** — part of the Account Management multi-role work; coordinate rather than duplicate.
+- [ ] **Unpublish (not delete) `Player` row when Player role is removed**.
+- [ ] **Admin dashboard: publish/unpublish and edit a roster entry** (bio, photo, hometown, etc.).
+- [ ] **Decide whether `teams.json` migrates to Prisma alongside `Player`, or stays static** — open question, teams change far less often than rosters; resolve before filing the `Player` migration issue so the scope is settled up front.


### PR DESCRIPTION
## Summary
- Adds `docs/features.md` (index) and `docs/features/*.md` — one requirement doc per site capability (Public Content, News, Teams & Rosters, Shop, Auth & Account Access, Event Scheduling & Attendance, Account Management, Membership & Fees, Audit Log), each with a problem statement, user stories, acceptance criteria, out-of-scope, current-vs-target table, data-model-changes section, and a checklist of candidate GitHub issues.
- Adds `CONTEXT.md`, a domain glossary pinning down "Feature (Capability)", "Requirement document", and "Workitem" for this effort.
- Permissions stay single-sourced in the existing `docs/roles-and-permissions.md` — these docs reference it rather than duplicating the matrix.
- Flags that the Shop feature (`src/app/shop/`, `src/app/dashboard/shop/`) was previously undocumented anywhere in the repo, and that the roles spec has no permission row for it yet.

Produced via a `/grilling` session (see `CONTEXT.md` for the resulting terminology) to pin down scope, granularity, template, and process before writing.

## Test plan
- [ ] Docs-only change — no app code touched; `npm run build && npm run lint` not required but can be run for sanity if desired.
- [ ] Review each doc under `docs/features/` for accuracy against current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)